### PR TITLE
Add unit tests for catalog-service and H2 test dependency

### DIFF
--- a/catalog-service/pom.xml
+++ b/catalog-service/pom.xml
@@ -96,6 +96,11 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/catalog-service/src/test/java/com/example/catalog/application/brand/BrandCommandServiceTest.java
+++ b/catalog-service/src/test/java/com/example/catalog/application/brand/BrandCommandServiceTest.java
@@ -1,0 +1,39 @@
+package com.example.catalog.application.brand;
+
+import com.example.catalog.domain.brand.Brand;
+import com.example.catalog.domain.brand.BrandRepository;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class BrandCommandServiceTest {
+
+    BrandRepository repo = mock(BrandRepository.class);
+    BrandCommandService svc = new BrandCommandService(repo);
+
+    @Test
+    void create_saves() {
+        when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        Brand b = svc.create("B", null);
+        assertThat(b.getName()).isEqualTo("B");
+        assertThat(b.isActive()).isTrue();
+        verify(repo).save(any());
+    }
+
+    @Test
+    void update_merges() {
+        UUID id = UUID.randomUUID();
+        Brand current = Brand.builder().id(id).name("B").active(true).build();
+        when(repo.findById(id)).thenReturn(Optional.of(current));
+        when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        Brand updated = svc.update(id, "B2", false);
+        assertThat(updated.getName()).isEqualTo("B2");
+        assertThat(updated.isActive()).isFalse();
+    }
+}
+

--- a/catalog-service/src/test/java/com/example/catalog/application/brand/BrandQueryServiceTest.java
+++ b/catalog-service/src/test/java/com/example/catalog/application/brand/BrandQueryServiceTest.java
@@ -1,0 +1,19 @@
+package com.example.catalog.application.brand;
+
+import com.example.catalog.domain.brand.BrandRepository;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.*;
+
+class BrandQueryServiceTest {
+
+    BrandRepository repo = mock(BrandRepository.class);
+    BrandQueryService svc = new BrandQueryService(repo);
+
+    @Test
+    void list_delegates() {
+        svc.list(true);
+        verify(repo).findAll(true);
+    }
+}
+

--- a/catalog-service/src/test/java/com/example/catalog/application/category/CategoryCommandServiceTest.java
+++ b/catalog-service/src/test/java/com/example/catalog/application/category/CategoryCommandServiceTest.java
@@ -1,0 +1,42 @@
+package com.example.catalog.application.category;
+
+import com.example.catalog.domain.category.Category;
+import com.example.catalog.domain.category.CategoryRepository;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class CategoryCommandServiceTest {
+
+    CategoryRepository repo = mock(CategoryRepository.class);
+    CategoryCommandService svc = new CategoryCommandService(repo);
+
+    @Test
+    void create_savesWithDefaults() {
+        when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        Category c = svc.create("Name", null, null, 5);
+        assertThat(c.getName()).isEqualTo("Name");
+        assertThat(c.isActive()).isTrue();
+        assertThat(c.getSortOrder()).isEqualTo(5);
+        verify(repo).save(any());
+    }
+
+    @Test
+    void update_mergesAndSaves() {
+        UUID id = UUID.randomUUID();
+        Category existing = Category.builder().id(id).name("A").active(true).sortOrder(1).build();
+        when(repo.findById(id)).thenReturn(Optional.of(existing));
+        when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        Category updated = svc.update(id, "B", null, false, 2);
+        assertThat(updated.getName()).isEqualTo("B");
+        assertThat(updated.isActive()).isFalse();
+        assertThat(updated.getSortOrder()).isEqualTo(2);
+    }
+}
+

--- a/catalog-service/src/test/java/com/example/catalog/application/category/CategoryQueryServiceTest.java
+++ b/catalog-service/src/test/java/com/example/catalog/application/category/CategoryQueryServiceTest.java
@@ -1,0 +1,28 @@
+package com.example.catalog.application.category;
+
+import com.example.catalog.domain.category.CategoryRepository;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.mockito.Mockito.*;
+
+class CategoryQueryServiceTest {
+
+    CategoryRepository repo = mock(CategoryRepository.class);
+    CategoryQueryService svc = new CategoryQueryService(repo);
+
+    @Test
+    void list_withParent_callsParentRepo() {
+        UUID pid = UUID.randomUUID();
+        svc.list(true, pid);
+        verify(repo).findByParent(pid, true);
+    }
+
+    @Test
+    void list_withoutParent_callsFindAll() {
+        svc.list(null, null);
+        verify(repo).findAll(null);
+    }
+}
+

--- a/catalog-service/src/test/java/com/example/catalog/application/product/ProductCommandServiceTest.java
+++ b/catalog-service/src/test/java/com/example/catalog/application/product/ProductCommandServiceTest.java
@@ -1,0 +1,44 @@
+package com.example.catalog.application.product;
+
+import com.example.catalog.domain.product.Product;
+import com.example.catalog.domain.product.ProductRepository;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class ProductCommandServiceTest {
+
+    ProductRepository repo = mock(ProductRepository.class);
+    ProductCommandService svc = new ProductCommandService(repo);
+
+    @Test
+    void create_setsTimestampsAndSaves() {
+        when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        Product p = svc.create("P","d",UUID.randomUUID(),UUID.randomUUID(),true);
+        assertThat(p.getName()).isEqualTo("P");
+        assertThat(p.getCreatedAt()).isNotNull();
+        verify(repo).save(any());
+    }
+
+    @Test
+    void update_mergesFields() {
+        UUID id = UUID.randomUUID();
+        Product current = Product.builder().id(id).name("P").shortDesc("d")
+                .brandId(UUID.randomUUID()).categoryId(UUID.randomUUID())
+                .published(false).createdAt(java.time.Instant.now())
+                .updatedAt(java.time.Instant.now()).build();
+        when(repo.findById(id)).thenReturn(Optional.of(current));
+        when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        Product updated = svc.update(id, "P2", "d2", null, null, true);
+        assertThat(updated.getName()).isEqualTo("P2");
+        assertThat(updated.getShortDesc()).isEqualTo("d2");
+        assertThat(updated.isPublished()).isTrue();
+    }
+}
+

--- a/catalog-service/src/test/java/com/example/catalog/application/product/ProductQueryServiceTest.java
+++ b/catalog-service/src/test/java/com/example/catalog/application/product/ProductQueryServiceTest.java
@@ -1,0 +1,32 @@
+package com.example.catalog.application.product;
+
+import com.example.catalog.domain.product.ProductRepository;
+import com.example.catalog.domain.product.ProductSearchCriteria;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class ProductQueryServiceTest {
+
+    ProductRepository repo = mock(ProductRepository.class);
+    ProductQueryService svc = new ProductQueryService(repo);
+
+    @Test
+    void search_delegates() {
+        svc.search("q", UUID.randomUUID(), null, 0, 10);
+        verify(repo).search(any(ProductSearchCriteria.class));
+    }
+
+    @Test
+    void getById_callsRepo() {
+        UUID id = UUID.randomUUID();
+        try {
+            svc.getById(id);
+        } catch (Exception ignored) {}
+        verify(repo).findById(id);
+    }
+}
+

--- a/catalog-service/src/test/java/com/example/catalog/application/sku/SkuCommandServiceTest.java
+++ b/catalog-service/src/test/java/com/example/catalog/application/sku/SkuCommandServiceTest.java
@@ -1,0 +1,40 @@
+package com.example.catalog.application.sku;
+
+import com.example.catalog.domain.sku.Sku;
+import com.example.catalog.domain.sku.SkuRepository;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class SkuCommandServiceTest {
+
+    SkuRepository repo = mock(SkuRepository.class);
+    SkuCommandService svc = new SkuCommandService(repo);
+
+    @Test
+    void create_saves() {
+        when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        Sku s = svc.create(UUID.randomUUID(), "S", null, null);
+        assertThat(s.getSkuCode()).isEqualTo("S");
+        assertThat(s.isActive()).isTrue();
+        verify(repo).save(any());
+    }
+
+    @Test
+    void update_merges() {
+        UUID id = UUID.randomUUID();
+        Sku current = Sku.builder().id(id).productId(UUID.randomUUID()).skuCode("S").active(true).barcode("b").build();
+        when(repo.findById(id)).thenReturn(Optional.of(current));
+        when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        Sku updated = svc.update(id, "S2", false, "b2");
+        assertThat(updated.getSkuCode()).isEqualTo("S2");
+        assertThat(updated.isActive()).isFalse();
+        assertThat(updated.getBarcode()).isEqualTo("b2");
+    }
+}
+

--- a/catalog-service/src/test/java/com/example/catalog/application/sku/SkuQueryServiceTest.java
+++ b/catalog-service/src/test/java/com/example/catalog/application/sku/SkuQueryServiceTest.java
@@ -1,0 +1,22 @@
+package com.example.catalog.application.sku;
+
+import com.example.catalog.domain.sku.SkuRepository;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.mockito.Mockito.*;
+
+class SkuQueryServiceTest {
+
+    SkuRepository repo = mock(SkuRepository.class);
+    SkuQueryService svc = new SkuQueryService(repo);
+
+    @Test
+    void byProduct_delegates() {
+        UUID pid = UUID.randomUUID();
+        svc.byProduct(pid);
+        verify(repo).findByProductId(pid);
+    }
+}
+

--- a/catalog-service/src/test/java/com/example/catalog/config/BeanConfigWiringTest.java
+++ b/catalog-service/src/test/java/com/example/catalog/config/BeanConfigWiringTest.java
@@ -1,0 +1,95 @@
+package com.example.catalog.config;
+
+import com.example.catalog.application.brand.*;
+import com.example.catalog.application.category.*;
+import com.example.catalog.application.product.*;
+import com.example.catalog.application.sku.*;
+import com.example.catalog.domain.brand.BrandRepository;
+import com.example.catalog.domain.category.CategoryRepository;
+import com.example.catalog.domain.product.ProductRepository;
+import com.example.catalog.domain.sku.SkuRepository;
+import com.example.catalog.infrastructure.jpa.repository.*;
+import com.example.catalog.security.IamEntitlementsClient;
+import com.example.catalog.application.authz.EntitlementsQuery;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestConstructor;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringJUnitConfig
+@ContextConfiguration(classes = {CatalogBeanConfig.class, AuthzBeanConfig.class})
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+class BeanConfigWiringTest {
+
+    @MockBean JpaCategoryRepository jpaCategoryRepository;
+    @MockBean JpaBrandRepository jpaBrandRepository;
+    @MockBean JpaProductRepository jpaProductRepository;
+    @MockBean JpaSkuRepository jpaSkuRepository;
+    @MockBean IamEntitlementsClient iamEntitlementsClient;
+
+    private final CategoryRepository categoryRepository;
+    private final BrandRepository brandRepository;
+    private final ProductRepository productRepository;
+    private final SkuRepository skuRepository;
+
+    private final CategoryCommands categoryCommands;
+    private final CategoryQueries categoryQueries;
+    private final BrandCommands brandCommands;
+    private final BrandQueries brandQueries;
+    private final ProductCommands productCommands;
+    private final ProductQueries productQueries;
+    private final SkuCommands skuCommands;
+    private final SkuQueries skuQueries;
+
+    private final EntitlementsQuery entitlementsQuery;
+
+    BeanConfigWiringTest(CategoryRepository categoryRepository,
+                         BrandRepository brandRepository,
+                         ProductRepository productRepository,
+                         SkuRepository skuRepository,
+                         CategoryCommands categoryCommands,
+                         CategoryQueries categoryQueries,
+                         BrandCommands brandCommands,
+                         BrandQueries brandQueries,
+                         ProductCommands productCommands,
+                         ProductQueries productQueries,
+                         SkuCommands skuCommands,
+                         SkuQueries skuQueries,
+                         EntitlementsQuery entitlementsQuery) {
+        this.categoryRepository = categoryRepository;
+        this.brandRepository = brandRepository;
+        this.productRepository = productRepository;
+        this.skuRepository = skuRepository;
+        this.categoryCommands = categoryCommands;
+        this.categoryQueries = categoryQueries;
+        this.brandCommands = brandCommands;
+        this.brandQueries = brandQueries;
+        this.productCommands = productCommands;
+        this.productQueries = productQueries;
+        this.skuCommands = skuCommands;
+        this.skuQueries = skuQueries;
+        this.entitlementsQuery = entitlementsQuery;
+    }
+
+    @Test
+    void beans_present() {
+        assertThat(categoryRepository).isNotNull();
+        assertThat(brandRepository).isNotNull();
+        assertThat(productRepository).isNotNull();
+        assertThat(skuRepository).isNotNull();
+
+        assertThat(categoryCommands).isNotNull();
+        assertThat(categoryQueries).isNotNull();
+        assertThat(brandCommands).isNotNull();
+        assertThat(brandQueries).isNotNull();
+        assertThat(productCommands).isNotNull();
+        assertThat(productQueries).isNotNull();
+        assertThat(skuCommands).isNotNull();
+        assertThat(skuQueries).isNotNull();
+        assertThat(entitlementsQuery).isNotNull();
+    }
+}
+

--- a/catalog-service/src/test/java/com/example/catalog/infrastructure/iam/CachedEntitlementsQueryTest.java
+++ b/catalog-service/src/test/java/com/example/catalog/infrastructure/iam/CachedEntitlementsQueryTest.java
@@ -1,0 +1,40 @@
+package com.example.catalog.infrastructure.iam;
+
+import com.example.catalog.security.EntitlementsDto;
+import com.example.catalog.security.IamClientProperties;
+import com.example.catalog.security.IamEntitlementsClient;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class CachedEntitlementsQueryTest {
+
+    IamEntitlementsClient client = mock(IamEntitlementsClient.class);
+    IamClientProperties props = new IamClientProperties();
+    CachedEntitlementsQuery query = new CachedEntitlementsQuery(Caffeine.newBuilder().build(), client, props);
+
+    @Test
+    void fetchesAndCaches() {
+        UUID id = UUID.randomUUID();
+        when(client.fetch(id)).thenReturn(new EntitlementsDto(1, List.of("a")));
+
+        Collection<GrantedAuthority> first = query.findAuthorities(id, 1);
+        assertThat(first).extracting(GrantedAuthority::getAuthority).contains("SCOPE_a");
+        verify(client, times(1)).fetch(id);
+
+        Collection<GrantedAuthority> second = query.findAuthorities(id, 1);
+        assertThat(second).hasSize(1);
+        verify(client, times(1)).fetch(id); // cached
+
+        query.findAuthorities(id, 2); // permVer changed -> re-fetch
+        verify(client, times(2)).fetch(id);
+    }
+}
+

--- a/catalog-service/src/test/java/com/example/catalog/infrastructure/jpa/BrandRepositoryImplTest.java
+++ b/catalog-service/src/test/java/com/example/catalog/infrastructure/jpa/BrandRepositoryImplTest.java
@@ -1,0 +1,50 @@
+package com.example.catalog.infrastructure.jpa;
+
+import com.example.catalog.domain.brand.Brand;
+import com.example.catalog.infrastructure.jpa.entity.JpaBrand;
+import com.example.catalog.infrastructure.jpa.repository.JpaBrandRepository;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class BrandRepositoryImplTest {
+
+    JpaBrandRepository jpa = mock(JpaBrandRepository.class);
+    BrandRepositoryImpl repo = new BrandRepositoryImpl(jpa);
+
+    @Test
+    void save_maps() {
+        UUID id = UUID.randomUUID();
+        when(jpa.save(any())).thenReturn(JpaBrand.builder().id(id).name("B").active(true).build());
+        Brand res = repo.save(Brand.builder().id(id).name("B").active(true).build());
+        assertThat(res.getId()).isEqualTo(id);
+    }
+
+    @Test
+    void findAll_activeNull_callsFindAll() {
+        when(jpa.findAll()).thenReturn(List.of());
+        repo.findAll(null);
+        verify(jpa).findAll();
+    }
+
+    @Test
+    void findAll_activeNotNull_callsFindByActive() {
+        when(jpa.findByActive(false)).thenReturn(List.of());
+        repo.findAll(false);
+        verify(jpa).findByActive(false);
+    }
+
+    @Test
+    void findById_maps() {
+        UUID id = UUID.randomUUID();
+        when(jpa.findById(id)).thenReturn(Optional.of(JpaBrand.builder().id(id).name("B").active(true).build()));
+        assertThat(repo.findById(id)).isPresent();
+    }
+}
+

--- a/catalog-service/src/test/java/com/example/catalog/infrastructure/jpa/CategoryRepositoryImplTest.java
+++ b/catalog-service/src/test/java/com/example/catalog/infrastructure/jpa/CategoryRepositoryImplTest.java
@@ -1,0 +1,54 @@
+package com.example.catalog.infrastructure.jpa;
+
+import com.example.catalog.domain.category.Category;
+import com.example.catalog.infrastructure.jpa.entity.JpaCategory;
+import com.example.catalog.infrastructure.jpa.repository.JpaCategoryRepository;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class CategoryRepositoryImplTest {
+
+    JpaCategoryRepository jpa = mock(JpaCategoryRepository.class);
+    CategoryRepositoryImpl repo = new CategoryRepositoryImpl(jpa);
+
+    @Test
+    void save_mapsAndDelegates() {
+        UUID id = UUID.randomUUID();
+        when(jpa.save(any())).thenReturn(JpaCategory.builder().id(id).name("C").active(true).build());
+        Category res = repo.save(Category.builder().id(id).name("C").active(true).build());
+        assertThat(res.getId()).isEqualTo(id);
+        verify(jpa).save(any());
+    }
+
+    @Test
+    void findByParent_activeNull_callsFindByParentId() {
+        UUID pid = UUID.randomUUID();
+        when(jpa.findByParentId(pid)).thenReturn(List.of());
+        repo.findByParent(pid, null);
+        verify(jpa).findByParentId(pid);
+    }
+
+    @Test
+    void findAll_activeNotNull_callsFindByActive() {
+        when(jpa.findByActive(true)).thenReturn(List.of());
+        repo.findAll(true);
+        verify(jpa).findByActive(true);
+    }
+
+    @Test
+    void findById_maps() {
+        UUID id = UUID.randomUUID();
+        when(jpa.findById(id)).thenReturn(Optional.of(JpaCategory.builder().id(id).name("C").active(true).build()));
+        Optional<Category> res = repo.findById(id);
+        assertThat(res).isPresent();
+        assertThat(res.get().getId()).isEqualTo(id);
+    }
+}
+

--- a/catalog-service/src/test/java/com/example/catalog/infrastructure/jpa/ProductRepositoryImplTest.java
+++ b/catalog-service/src/test/java/com/example/catalog/infrastructure/jpa/ProductRepositoryImplTest.java
@@ -1,0 +1,58 @@
+package com.example.catalog.infrastructure.jpa;
+
+import com.example.catalog.domain.common.PageResult;
+import com.example.catalog.domain.product.Product;
+import com.example.catalog.domain.product.ProductSearchCriteria;
+import com.example.catalog.infrastructure.jpa.entity.JpaProduct;
+import com.example.catalog.infrastructure.jpa.repository.JpaProductRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class ProductRepositoryImplTest {
+
+    JpaProductRepository jpa = mock(JpaProductRepository.class);
+    ProductRepositoryImpl repo = new ProductRepositoryImpl(jpa);
+
+    @Test
+    void save_maps() {
+        UUID id = UUID.randomUUID();
+        when(jpa.save(any())).thenReturn(JpaProduct.builder().id(id).name("P").shortDesc("d").brandId(UUID.randomUUID()).categoryId(UUID.randomUUID()).published(true).createdAt(Instant.now()).updatedAt(Instant.now()).build());
+        Product res = repo.save(Product.builder().id(id).name("P").shortDesc("d").brandId(UUID.randomUUID()).categoryId(UUID.randomUUID()).published(true).createdAt(Instant.now()).updatedAt(Instant.now()).build());
+        assertThat(res.getId()).isEqualTo(id);
+    }
+
+    @Test
+    void findById_maps() {
+        UUID id = UUID.randomUUID();
+        when(jpa.findById(id)).thenReturn(Optional.of(JpaProduct.builder().id(id).name("P").shortDesc("d").brandId(UUID.randomUUID()).categoryId(UUID.randomUUID()).published(true).createdAt(Instant.now()).updatedAt(Instant.now()).build()));
+        assertThat(repo.findById(id)).isPresent();
+    }
+
+    @Test
+    void search_buildsPageRequest() {
+        ArgumentCaptor<PageRequest> captor = ArgumentCaptor.forClass(PageRequest.class);
+        Page<JpaProduct> page = new PageImpl<>(List.of());
+        when(jpa.findAll(any(Specification.class), any(PageRequest.class))).thenReturn(page);
+
+        PageResult<Product> res = repo.search(new ProductSearchCriteria("q", null, null, -1, 0));
+
+        verify(jpa).findAll(any(Specification.class), captor.capture());
+        assertThat(captor.getValue().getPageNumber()).isZero();
+        assertThat(captor.getValue().getPageSize()).isEqualTo(1);
+        assertThat(res.content()).isEmpty();
+    }
+}
+

--- a/catalog-service/src/test/java/com/example/catalog/infrastructure/jpa/SkuRepositoryImplTest.java
+++ b/catalog-service/src/test/java/com/example/catalog/infrastructure/jpa/SkuRepositoryImplTest.java
@@ -1,0 +1,45 @@
+package com.example.catalog.infrastructure.jpa;
+
+import com.example.catalog.domain.sku.Sku;
+import com.example.catalog.infrastructure.jpa.entity.JpaSku;
+import com.example.catalog.infrastructure.jpa.repository.JpaSkuRepository;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class SkuRepositoryImplTest {
+
+    JpaSkuRepository jpa = mock(JpaSkuRepository.class);
+    SkuRepositoryImpl repo = new SkuRepositoryImpl(jpa);
+
+    @Test
+    void save_maps() {
+        UUID id = UUID.randomUUID();
+        when(jpa.save(any())).thenReturn(JpaSku.builder().id(id).productId(UUID.randomUUID()).skuCode("S").active(true).build());
+        Sku res = repo.save(Sku.builder().id(id).productId(UUID.randomUUID()).skuCode("S").active(true).build());
+        assertThat(res.getId()).isEqualTo(id);
+    }
+
+    @Test
+    void findByProductId_mapsList() {
+        UUID pid = UUID.randomUUID();
+        when(jpa.findByProductId(pid)).thenReturn(List.of(JpaSku.builder().id(UUID.randomUUID()).productId(pid).skuCode("S").active(true).build()));
+        List<Sku> list = repo.findByProductId(pid);
+        assertThat(list).hasSize(1);
+        verify(jpa).findByProductId(pid);
+    }
+
+    @Test
+    void findById_maps() {
+        UUID id = UUID.randomUUID();
+        when(jpa.findById(id)).thenReturn(Optional.of(JpaSku.builder().id(id).productId(UUID.randomUUID()).skuCode("S").active(true).build()));
+        assertThat(repo.findById(id)).isPresent();
+    }
+}
+

--- a/catalog-service/src/test/java/com/example/catalog/security/IamEntitlementsClientTest.java
+++ b/catalog-service/src/test/java/com/example/catalog/security/IamEntitlementsClientTest.java
@@ -1,0 +1,45 @@
+package com.example.catalog.security;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.ExpectedCount.once;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
+
+class IamEntitlementsClientTest {
+
+    RestTemplate rt = new RestTemplate();
+    IamClientProperties props = new IamClientProperties();
+    IamEntitlementsClient client = new IamEntitlementsClient(rt, props);
+
+    @Test
+    void fetch_ok() {
+        props.setInternalAuthValue("secret");
+        MockRestServiceServer server = MockRestServiceServer.bindTo(rt).build();
+        UUID id = UUID.randomUUID();
+        server.expect(once(), requestTo("http://iam-service/internal/v1/entitlements/"+id))
+                .andExpect(header("X-Internal-Token", "secret"))
+                .andRespond(withSuccess("{\"perm_ver\":1,\"scopes\":[\"a\"]}", MediaType.APPLICATION_JSON));
+
+        EntitlementsDto dto = client.fetch(id);
+        assertThat(dto.perm_ver()).isEqualTo(1);
+        server.verify();
+    }
+
+    @Test
+    void fetch_error_returnsEmpty() {
+        MockRestServiceServer server = MockRestServiceServer.bindTo(rt).build();
+        UUID id = UUID.randomUUID();
+        server.expect(once(), requestTo("http://iam-service/internal/v1/entitlements/"+id))
+                .andRespond(withServerError());
+        EntitlementsDto dto = client.fetch(id);
+        assertThat(dto.scopes()).isEmpty();
+    }
+}
+

--- a/catalog-service/src/test/java/com/example/catalog/security/ScopeAuthorityAugmentorFilterTest.java
+++ b/catalog-service/src/test/java/com/example/catalog/security/ScopeAuthorityAugmentorFilterTest.java
@@ -1,0 +1,54 @@
+package com.example.catalog.security;
+
+import com.example.catalog.application.authz.EntitlementsQuery;
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class ScopeAuthorityAugmentorFilterTest {
+
+    EntitlementsQuery eq = mock(EntitlementsQuery.class);
+    ScopeAuthorityAugmentorFilter filter = new ScopeAuthorityAugmentorFilter(eq);
+
+    @Test
+    void augment_addsAuthorities() throws Exception {
+        UUID id = UUID.randomUUID();
+        when(eq.findAuthorities(id, 1)).thenReturn(List.of(new SimpleGrantedAuthority("SCOPE_a")));
+        Jwt jwt = Jwt.withTokenValue("t").header("alg","none")
+                .claim("sub", id.toString()).claim("perm_ver",1).build();
+        Authentication auth = new JwtAuthenticationToken(jwt, List.of(new SimpleGrantedAuthority("ROLE_U")));
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        filter.doFilterInternal(new MockHttpServletRequest(), new MockHttpServletResponse(), new MockFilterChain());
+
+        Authentication augmented = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(augmented.getAuthorities()).extracting(Object::toString)
+                .contains("SCOPE_a", "ROLE_U");
+    }
+
+    @Test
+    void invalidSub_skipsFetch() throws Exception {
+        Jwt jwt = Jwt.withTokenValue("t").header("alg","none")
+                .claim("sub", "x").build();
+        Authentication auth = new JwtAuthenticationToken(jwt, List.of());
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        filter.doFilterInternal(new MockHttpServletRequest(), new MockHttpServletResponse(), new MockFilterChain());
+        verify(eq, never()).findAuthorities(any(), any());
+    }
+}
+

--- a/catalog-service/src/test/java/com/example/catalog/web/AdminCatalogControllerTest.java
+++ b/catalog-service/src/test/java/com/example/catalog/web/AdminCatalogControllerTest.java
@@ -1,0 +1,179 @@
+package com.example.catalog.web;
+
+import com.example.catalog.application.brand.BrandCommands;
+import com.example.catalog.application.category.CategoryCommands;
+import com.example.catalog.application.product.ProductCommands;
+import com.example.catalog.application.sku.SkuCommands;
+import com.example.catalog.domain.brand.Brand;
+import com.example.catalog.domain.category.Category;
+import com.example.catalog.domain.product.Product;
+import com.example.catalog.domain.sku.Sku;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = AdminCatalogController.class)
+@Import({GlobalExceptionHandler.class, WebTestConfig.class})
+class AdminCatalogControllerTest {
+
+    @Autowired MockMvc mvc;
+
+    @MockBean CategoryCommands categoryCommands;
+    @MockBean BrandCommands brandCommands;
+    @MockBean ProductCommands productCommands;
+    @MockBean SkuCommands skuCommands;
+
+    private final ObjectMapper om = new ObjectMapper();
+
+    @Test
+    void createCategory_ok() throws Exception {
+        var c = Category.builder().id(UUID.randomUUID()).name("C").active(true).build();
+        when(categoryCommands.create(any(), any(), any(), any())).thenReturn(c);
+
+        mvc.perform(post("/api/v1/admin/categories")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(om.writeValueAsBytes(Map.of("name","C"))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name").value("C"));
+    }
+
+    @Test
+    void updateCategory_ok() throws Exception {
+        UUID id = UUID.randomUUID();
+        var c = Category.builder().id(id).name("CC").active(true).build();
+        when(categoryCommands.update(eq(id), any(), any(), any(), any())).thenReturn(c);
+
+        mvc.perform(put("/api/v1/admin/categories/"+id)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(om.writeValueAsBytes(Map.of("name","CC"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("CC"));
+    }
+
+    @Test
+    void deleteCategory_ok() throws Exception {
+        UUID id = UUID.randomUUID();
+        mvc.perform(delete("/api/v1/admin/categories/"+id))
+                .andExpect(status().isNoContent());
+        verify(categoryCommands).delete(id);
+    }
+
+    @Test
+    void createBrand_ok() throws Exception {
+        var b = Brand.builder().id(UUID.randomUUID()).name("B").active(true).build();
+        when(brandCommands.create(any(), any())).thenReturn(b);
+
+        mvc.perform(post("/api/v1/admin/brands")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(om.writeValueAsBytes(Map.of("name","B"))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name").value("B"));
+    }
+
+    @Test
+    void updateBrand_ok() throws Exception {
+        UUID id = UUID.randomUUID();
+        var b = Brand.builder().id(id).name("BB").active(false).build();
+        when(brandCommands.update(eq(id), any(), any())).thenReturn(b);
+
+        mvc.perform(put("/api/v1/admin/brands/"+id)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(om.writeValueAsBytes(Map.of("name","BB","active",false))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("BB"))
+                .andExpect(jsonPath("$.active").value(false));
+    }
+
+    @Test
+    void deleteBrand_ok() throws Exception {
+        UUID id = UUID.randomUUID();
+        mvc.perform(delete("/api/v1/admin/brands/"+id))
+                .andExpect(status().isNoContent());
+        verify(brandCommands).delete(id);
+    }
+
+    @Test
+    void createProduct_ok() throws Exception {
+        var p = Product.builder().id(UUID.randomUUID()).name("P").shortDesc("d")
+                .brandId(UUID.randomUUID()).categoryId(UUID.randomUUID())
+                .published(true).createdAt(Instant.now()).updatedAt(Instant.now()).build();
+        when(productCommands.create(any(), any(), any(), any(), any())).thenReturn(p);
+
+        mvc.perform(post("/api/v1/admin/products")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(om.writeValueAsBytes(Map.of("name","P","shortDesc","d"))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name").value("P"));
+    }
+
+    @Test
+    void updateProduct_ok() throws Exception {
+        UUID id = UUID.randomUUID();
+        var p = Product.builder().id(id).name("PP").shortDesc("d")
+                .brandId(UUID.randomUUID()).categoryId(UUID.randomUUID())
+                .published(true).createdAt(Instant.now()).updatedAt(Instant.now()).build();
+        when(productCommands.update(eq(id), any(), any(), any(), any(), any())).thenReturn(p);
+
+        mvc.perform(put("/api/v1/admin/products/"+id)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(om.writeValueAsBytes(Map.of("name","PP"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("PP"));
+    }
+
+    @Test
+    void deleteProduct_ok() throws Exception {
+        UUID id = UUID.randomUUID();
+        mvc.perform(delete("/api/v1/admin/products/"+id))
+                .andExpect(status().isNoContent());
+        verify(productCommands).delete(id);
+    }
+
+    @Test
+    void createSku_ok() throws Exception {
+        UUID pid = UUID.randomUUID();
+        var s = Sku.builder().id(UUID.randomUUID()).productId(pid).skuCode("S").active(true).build();
+        when(skuCommands.create(eq(pid), any(), any(), any())).thenReturn(s);
+
+        mvc.perform(post("/api/v1/admin/products/"+pid+"/skus")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(om.writeValueAsBytes(Map.of("skuCode","S"))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.skuCode").value("S"));
+    }
+
+    @Test
+    void updateSku_ok() throws Exception {
+        UUID id = UUID.randomUUID();
+        var s = Sku.builder().id(id).productId(UUID.randomUUID()).skuCode("SS").active(true).build();
+        when(skuCommands.update(eq(id), any(), any(), any())).thenReturn(s);
+
+        mvc.perform(put("/api/v1/admin/skus/"+id)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(om.writeValueAsBytes(Map.of("skuCode","SS"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.skuCode").value("SS"));
+    }
+
+    @Test
+    void deleteSku_ok() throws Exception {
+        UUID id = UUID.randomUUID();
+        mvc.perform(delete("/api/v1/admin/skus/"+id))
+                .andExpect(status().isNoContent());
+        verify(skuCommands).delete(id);
+    }
+}
+

--- a/catalog-service/src/test/java/com/example/catalog/web/PingControllerTest.java
+++ b/catalog-service/src/test/java/com/example/catalog/web/PingControllerTest.java
@@ -1,0 +1,50 @@
+package com.example.catalog.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = PingController.class)
+@Import({GlobalExceptionHandler.class, WebTestConfig.class})
+class PingControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    private final ObjectMapper om = new ObjectMapper();
+
+    @Test
+    void ping_ok() throws Exception {
+        mvc.perform(get("/api/v1/ping"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("pong"));
+    }
+
+    @Test
+    void secure_ok() throws Exception {
+        mvc.perform(get("/api/v1/secure"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("secured"));
+    }
+
+    @Test
+    void echo_ok() throws Exception {
+        mvc.perform(post("/api/v1/echo").param("text", "hi"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.echo").value("hi"));
+    }
+
+    @Test
+    void echo_blank_400() throws Exception {
+        mvc.perform(post("/api/v1/echo").param("text", " "))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("bad_request:validation"));
+    }
+}
+

--- a/catalog-service/src/test/java/com/example/catalog/web/PublicCatalogControllerTest.java
+++ b/catalog-service/src/test/java/com/example/catalog/web/PublicCatalogControllerTest.java
@@ -1,0 +1,89 @@
+package com.example.catalog.web;
+
+import com.example.catalog.application.brand.BrandQueries;
+import com.example.catalog.application.category.CategoryQueries;
+import com.example.catalog.application.product.ProductQueries;
+import com.example.catalog.domain.brand.Brand;
+import com.example.catalog.domain.category.Category;
+import com.example.catalog.domain.common.PageResult;
+import com.example.catalog.domain.product.Product;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = PublicCatalogController.class)
+@Import({GlobalExceptionHandler.class, WebTestConfig.class})
+class PublicCatalogControllerTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @MockBean CategoryQueries categoryQueries;
+    @MockBean BrandQueries brandQueries;
+    @MockBean ProductQueries productQueries;
+
+    private final ObjectMapper om = new ObjectMapper();
+
+    @Test
+    void categories_ok() throws Exception {
+        when(categoryQueries.list(null, null)).thenReturn(List.of(Category.builder()
+                .id(UUID.randomUUID()).name("Cat").active(true).build()));
+
+        mvc.perform(get("/api/v1/catalog/categories"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].name").value("Cat"));
+    }
+
+    @Test
+    void brands_ok() throws Exception {
+        when(brandQueries.list(null)).thenReturn(List.of(Brand.builder()
+                .id(UUID.randomUUID()).name("Brand").active(true).build()));
+
+        mvc.perform(get("/api/v1/catalog/brands"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].name").value("Brand"));
+    }
+
+    @Test
+    void products_ok() throws Exception {
+        var p = Product.builder()
+                .id(UUID.randomUUID()).name("Prod").shortDesc("d")
+                .brandId(UUID.randomUUID()).categoryId(UUID.randomUUID())
+                .published(true)
+                .createdAt(Instant.now()).build();
+        when(productQueries.search(null, null, null, 0, 20))
+                .thenReturn(new PageResult<>(List.of(p),0,20,1,1));
+
+        mvc.perform(get("/api/v1/catalog/products"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].name").value("Prod"));
+    }
+
+    @Test
+    void productDetail_ok() throws Exception {
+        var p = Product.builder()
+                .id(UUID.randomUUID()).name("Prod").shortDesc("d")
+                .brandId(UUID.randomUUID()).categoryId(UUID.randomUUID())
+                .published(true)
+                .createdAt(Instant.now()).updatedAt(Instant.now()).build();
+        when(productQueries.getById(p.getId())).thenReturn(p);
+
+        mvc.perform(get("/api/v1/catalog/products/"+p.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Prod"));
+    }
+}
+

--- a/catalog-service/src/test/java/com/example/catalog/web/WebTestConfig.java
+++ b/catalog-service/src/test/java/com/example/catalog/web/WebTestConfig.java
@@ -1,0 +1,35 @@
+package com.example.catalog.web;
+
+import com.example.common.web.response.ErrorProps;
+import com.example.common.web.response.ErrorResponseBuilder;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * Test configuration to provide common beans and disable security for MVC tests.
+ */
+@TestConfiguration
+class WebTestConfig {
+
+    @Bean
+    ErrorProps errorProps() {
+        var p = new ErrorProps();
+        p.setVerbose(false);
+        return p;
+    }
+
+    @Bean
+    ErrorResponseBuilder errorResponseBuilder(ErrorProps props) {
+        return new ErrorResponseBuilder(props, "catalog-service");
+    }
+
+    @Bean
+    SecurityFilterChain testSecurity(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(reg -> reg.anyRequest().permitAll());
+        return http.build();
+    }
+}
+


### PR DESCRIPTION
## Summary
- add H2 as test dependency for catalog-service
- introduce comprehensive unit tests for catalog-service controllers, services, repositories, security, and bean wiring

## Testing
- `mvn -q -pl catalog-service test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b3cd5b48832ebb52a56bb903254e