### PR TITLE
Add unit tests for catalog-service and H2 test dependency

### DIFF
--- a/catalog-service/src/test/java/com/example/catalog/config/BeanConfigWiringTest.java
+++ b/catalog-service/src/test/java/com/example/catalog/config/BeanConfigWiringTest.java
@@ -12,15 +12,13 @@ import com.example.catalog.infrastructure.jpa.repository.*;
 import com.example.catalog.security.IamEntitlementsClient;
 import com.example.catalog.application.authz.EntitlementsQuery;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestConstructor;
-import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringJUnitConfig
-@ContextConfiguration(classes = {CatalogBeanConfig.class, AuthzBeanConfig.class})
+@SpringBootTest(classes = {CatalogBeanConfig.class, AuthzBeanConfig.class})
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
 class BeanConfigWiringTest {
 


### PR DESCRIPTION
## Summary
- add H2 as test dependency for catalog-service
- introduce comprehensive unit tests for catalog-service controllers, services, repositories, security, and bean wiring
- run bean wiring test with Spring Boot bootstrap

## Testing
- `mvn -q -pl catalog-service test` *(fails: Non-resolvable import POM: The following artifacts could not be resolved: org.springframework.boot:spring-boot-dependencies:pom:3.3.13 (absent): Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:3.3.13 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b2bfcb555c832e926393a5ded44967