### PR TITLE
[catalog] Ensure unique slugs in migration

### DIFF
--- a/catalog-service/src/main/resources/db/migration/V3__add_product_slug.sql
+++ b/catalog-service/src/main/resources/db/migration/V3__add_product_slug.sql
@@ -1,9 +1,21 @@
 -- Add slug column to products
 ALTER TABLE products ADD COLUMN slug VARCHAR(220);
 
--- normalize name then slugify
-UPDATE products
-SET slug = trim(both '-' FROM regexp_replace(lower(name), '[^a-z0-9]+', '-', 'g'));
+-- generate slug for existing products and ensure uniqueness
+WITH normalized AS (
+    SELECT id,
+           trim(both '-' FROM regexp_replace(lower(name), '[^a-z0-9]+', '-', 'g')) AS base_slug
+    FROM products
+), deduped AS (
+    SELECT id,
+           base_slug,
+           row_number() OVER (PARTITION BY base_slug ORDER BY id) AS seq
+    FROM normalized
+)
+UPDATE products p
+SET slug = CASE WHEN d.seq = 1 THEN d.base_slug ELSE concat(d.base_slug, '-', d.seq) END
+FROM deduped d
+WHERE p.id = d.id;
 
 ALTER TABLE products ALTER COLUMN slug SET NOT NULL;
 CREATE UNIQUE INDEX uq_products_slug ON products(slug);


### PR DESCRIPTION
## Summary
- ensure Flyway migration de-duplicates product slugs using row numbers before adding unique index

## Testing
- `mvn -pl catalog-service test | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68b3e27b4020832eaa6de3ae855efdfd