### PR TITLE
[catalog] Improve test coverage for catalog service

### DIFF
--- a/catalog-service/src/test/java/com/example/catalog/application/product/ProductCommandServiceTest.java
+++ b/catalog-service/src/test/java/com/example/catalog/application/product/ProductCommandServiceTest.java
@@ -14,25 +14,53 @@ import static org.mockito.Mockito.*;
 
 class ProductCommandServiceTest {
 
-    ProductRepository repo = mock(ProductRepository.class);
-    ProductCommandService service = new ProductCommandService(repo);
+      ProductRepository repo = mock(ProductRepository.class);
+      ProductCommandService service = new ProductCommandService(repo);
 
     @Test
-    void create_generatesSlug() {
-        when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
-        var p = service.create("Acme Phone X", "desc", UUID.randomUUID(), UUID.randomUUID(), true);
-        assertThat(p.getSlug()).isEqualTo("acme-phone-x");
-    }
+      void create_generatesSlug() {
+          when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+          var p = service.create("Acme Phone X", "desc", UUID.randomUUID(), UUID.randomUUID(), true);
+          assertThat(p.getSlug()).isEqualTo("acme-phone-x");
+      }
+
+      @Test
+      void create_slugCollision_appendsIndex() {
+          var existing = Product.builder().id(UUID.randomUUID()).build();
+          when(repo.findBySlug("acme-phone-x")).thenReturn(Optional.of(existing));
+          when(repo.findBySlug("acme-phone-x-1")).thenReturn(Optional.empty());
+          when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+          var p = service.create("Acme Phone X", "desc", UUID.randomUUID(), UUID.randomUUID(), true);
+          assertThat(p.getSlug()).isEqualTo("acme-phone-x-1");
+      }
 
     @Test
-    void update_updatesSlug() {
-        UUID id = UUID.randomUUID();
-        var existing = Product.builder().id(id).name("Old").slug("old").shortDesc("d")
-                .brandId(UUID.randomUUID()).categoryId(UUID.randomUUID())
-                .published(true).createdAt(Instant.now()).updatedAt(Instant.now()).build();
-        when(repo.findById(id)).thenReturn(Optional.of(existing));
-        when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
-        var updated = service.update(id, "New Name", null, null, null, null);
-        assertThat(updated.getSlug()).isEqualTo("new-name");
-    }
+      void update_updatesSlug() {
+          UUID id = UUID.randomUUID();
+          var existing = Product.builder().id(id).name("Old").slug("old").shortDesc("d")
+                  .brandId(UUID.randomUUID()).categoryId(UUID.randomUUID())
+                  .published(true).createdAt(Instant.now()).updatedAt(Instant.now()).build();
+          when(repo.findById(id)).thenReturn(Optional.of(existing));
+          when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+          var updated = service.update(id, "New Name", null, null, null, null);
+          assertThat(updated.getSlug()).isEqualTo("new-name");
+      }
+
+      @Test
+      void update_optionalFieldsUpdated() {
+          UUID id = UUID.randomUUID();
+          UUID brand2 = UUID.randomUUID();
+          UUID cat2 = UUID.randomUUID();
+          var existing = Product.builder().id(id).name("Name").slug("name").shortDesc("d")
+                  .brandId(UUID.randomUUID()).categoryId(UUID.randomUUID())
+                  .published(true).createdAt(Instant.now()).updatedAt(Instant.now()).build();
+          when(repo.findById(id)).thenReturn(Optional.of(existing));
+          when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+          var updated = service.update(id, null, "newd", brand2, cat2, false);
+          assertThat(updated.getSlug()).isEqualTo("name");
+          assertThat(updated.getShortDesc()).isEqualTo("newd");
+          assertThat(updated.getBrandId()).isEqualTo(brand2);
+          assertThat(updated.getCategoryId()).isEqualTo(cat2);
+          assertThat(updated.isPublished()).isFalse();
+      }
 }

--- a/catalog-service/src/test/java/com/example/catalog/web/GlobalExceptionHandlerTest.java
+++ b/catalog-service/src/test/java/com/example/catalog/web/GlobalExceptionHandlerTest.java
@@ -1,0 +1,110 @@
+package com.example.catalog.web;
+
+import com.example.common.web.response.ErrorProps;
+import com.example.common.web.response.ErrorResponseBuilder;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GlobalExceptionHandlerTest {
+
+    private GlobalExceptionHandler handler;
+    private MockHttpServletRequest request;
+
+    @BeforeEach
+    void setup() {
+        var builder = new ErrorResponseBuilder(new ErrorProps(), "catalog-service");
+        handler = new GlobalExceptionHandler(builder);
+        request = new MockHttpServletRequest();
+        request.setRequestURI("/api/test");
+        request.setMethod("GET");
+    }
+
+    @Test
+    void badJson_returns400() {
+        HttpMessageNotReadableException ex = new HttpMessageNotReadableException("bad", new ServletServerHttpRequest(request));
+        ResponseEntity<?> resp = handler.badJson(request, ex);
+        assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
+    }
+
+    @Test
+    void beanValidation_returns400() throws Exception {
+        Method m = Dummy.class.getDeclaredMethod("dummy", String.class);
+        MethodParameter param = new MethodParameter(m, 0);
+        var br = new BeanPropertyBindingResult("t", "t");
+        br.addError(new FieldError("t", "field", "message"));
+        MethodArgumentNotValidException ex = new MethodArgumentNotValidException(param, br);
+        ResponseEntity<?> resp = handler.beanValidation(request, ex);
+        assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
+    }
+
+    static class Dummy { void dummy(String s) {} }
+
+    @Test
+    void notFound_returns404() {
+        ResponseEntity<?> resp = handler.notFound(request, new NoSuchElementException());
+        assertEquals(HttpStatus.NOT_FOUND, resp.getStatusCode());
+    }
+
+    @Test
+    void methodNotAllowed_returns405() {
+        HttpRequestMethodNotSupportedException ex = new HttpRequestMethodNotSupportedException("POST", List.of("GET"));
+        ResponseEntity<?> resp = handler.methodNotAllowed(request, ex);
+        assertEquals(HttpStatus.METHOD_NOT_ALLOWED, resp.getStatusCode());
+    }
+
+    @Test
+    void unsupportedMediaType_returns415() {
+        HttpMediaTypeNotSupportedException ex = new HttpMediaTypeNotSupportedException(MediaType.APPLICATION_XML, List.of(MediaType.APPLICATION_JSON));
+        ResponseEntity<?> resp = handler.unsupportedMediaType(request, ex);
+        assertEquals(HttpStatus.UNSUPPORTED_MEDIA_TYPE, resp.getStatusCode());
+    }
+
+    @Test
+    void dataConflict_returns409() {
+        ResponseEntity<?> resp = handler.dataConflict(request, new DataIntegrityViolationException("x"));
+        assertEquals(HttpStatus.CONFLICT, resp.getStatusCode());
+    }
+
+    @Test
+    void accessDenied_returns403() {
+        ResponseEntity<?> resp = handler.accessDenied(request, new AccessDeniedException("denied"));
+        assertEquals(HttpStatus.FORBIDDEN, resp.getStatusCode());
+    }
+
+    @Test
+    void unknown_returns500() {
+        ResponseEntity<?> resp = handler.unknown(request, new Exception("boom"));
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, resp.getStatusCode());
+    }
+
+    @Test
+    void respond_nullException_branch() throws Exception {
+        Method m = GlobalExceptionHandler.class.getDeclaredMethod("respond", HttpServletRequest.class, HttpStatus.class, String.class, String.class, Throwable.class, Map.class);
+        m.setAccessible(true);
+        ResponseEntity<?> resp = (ResponseEntity<?>) m.invoke(handler, request, HttpStatus.BAD_REQUEST, "code", "msg", null, null);
+        assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
+    }
+}
+


### PR DESCRIPTION
## Summary
- add unit tests for GlobalExceptionHandler covering various error responses
- expand ProductCommandService tests to cover slug collisions and optional field updates

## Testing
- `mvn -pl catalog-service -Pcoverage verify`


------
https://chatgpt.com/codex/tasks/task_e_68b3e54e17b4832e8d640a6e60f003f0