### PR TITLE
Aggregate Swagger docs via gateway

### DIFF
--- a/auth-service/pom.xml
+++ b/auth-service/pom.xml
@@ -65,6 +65,13 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
 
+        <!-- OpenAPI docs only (UI via gateway) -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-api</artifactId>
+            <version>${springdoc.version}</version>
+        </dependency>
+
         <!-- Resilience4j -->
         <dependency>
             <groupId>io.github.resilience4j</groupId>

--- a/auth-service/src/main/java/com/example/auth/config/OpenApiConfig.java
+++ b/auth-service/src/main/java/com/example/auth/config/OpenApiConfig.java
@@ -1,0 +1,18 @@
+package com.example.auth.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.servers.Server;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+    info = @Info(title = "Auth API", version = "v1", description = "Auth service API"),
+    servers = @Server(url = "/auth")
+)
+@SecurityScheme(name = "bearer-key", type = SecuritySchemeType.HTTP, scheme = "bearer", bearerFormat = "JWT")
+public class OpenApiConfig {
+}
+

--- a/auth-service/src/main/java/com/example/auth/config/SecurityConfig.java
+++ b/auth-service/src/main/java/com/example/auth/config/SecurityConfig.java
@@ -20,6 +20,7 @@ public class SecurityConfig {
         http.csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(reg -> reg
                         .requestMatchers("/api/v1/auth/**", "/.well-known/**", "/actuator/health").permitAll()
+                        .requestMatchers("/v3/api-docs/**").permitAll()
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/error").permitAll()
                         .anyRequest().authenticated()

--- a/catalog-service/pom.xml
+++ b/catalog-service/pom.xml
@@ -35,6 +35,13 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
 
+        <!-- OpenAPI docs only (UI via gateway) -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-api</artifactId>
+            <version>${springdoc.version}</version>
+        </dependency>
+
         <!-- Data JPA + PostgreSQL -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/catalog-service/src/main/java/com/example/catalog/config/OpenApiConfig.java
+++ b/catalog-service/src/main/java/com/example/catalog/config/OpenApiConfig.java
@@ -1,0 +1,18 @@
+package com.example.catalog.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.servers.Server;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+    info = @Info(title = "Catalog API", version = "v1", description = "Catalog service API"),
+    servers = @Server(url = "/catalog")
+)
+@SecurityScheme(name = "bearer-key", type = SecuritySchemeType.HTTP, scheme = "bearer", bearerFormat = "JWT")
+public class OpenApiConfig {
+}
+

--- a/catalog-service/src/main/java/com/example/catalog/config/SecurityConfig.java
+++ b/catalog-service/src/main/java/com/example/catalog/config/SecurityConfig.java
@@ -44,6 +44,7 @@ public class SecurityConfig {
                         // Public catalog reads
                         .requestMatchers(HttpMethod.GET, "/api/v1/catalog/**").permitAll()
                         .requestMatchers("/actuator/health","/actuator/info").permitAll()
+                        .requestMatchers("/v3/api-docs/**").permitAll()
 
                         // Admin endpoints (role-based)
                         .requestMatchers("/api/v1/admin/**").authenticated()

--- a/catalog-service/src/main/java/com/example/catalog/web/PingController.java
+++ b/catalog-service/src/main/java/com/example/catalog/web/PingController.java
@@ -8,25 +8,32 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 
 import java.util.Map;
 
 @Validated
 @RestController
 @RequestMapping("/api/v1")
+@Tag(name = "Ping")
 public class PingController {
 
     @GetMapping("/ping")
+    @Operation(summary = "Simple ping")
     public ResponseEntity<?> ping() {
         return ResponseEntity.ok(Map.of("message", "pong"));
     }
 
     @GetMapping("/secure")
+    @Operation(summary = "Secured ping", security = {@SecurityRequirement(name = "bearer-key")})
     public ResponseEntity<?> secure() {
         return ResponseEntity.ok(Map.of("message", "secured"));
     }
 
     @PostMapping("/echo")
+    @Operation(summary = "Echo text", security = {@SecurityRequirement(name = "bearer-key")})
     public ResponseEntity<?> echo(@RequestParam @NotBlank String text) {
         return ResponseEntity.ok(Map.of("echo", text));
     }

--- a/catalog-service/src/main/java/com/example/catalog/web/brand/BrandController.java
+++ b/catalog-service/src/main/java/com/example/catalog/web/brand/BrandController.java
@@ -10,6 +10,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 
 import java.util.List;
 import java.util.UUID;
@@ -17,11 +20,13 @@ import java.util.UUID;
 @Validated
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "Brands")
 public class BrandController {
     private final BrandQueries brandQueries;
     private final BrandCommands brandCommands;
 
     @GetMapping("/api/v1/catalog/brands")
+    @Operation(summary = "List brands")
     public List<BrandResponse> brands(@RequestParam(required = false) Boolean active) {
         return brandQueries.list(active).stream().map(DtoMapper::toDto).toList();
     }
@@ -29,6 +34,7 @@ public class BrandController {
     @PostMapping("/api/v1/admin/brands")
     @ResponseStatus(HttpStatus.CREATED)
     @PreAuthorize("hasAnyRole('ADMIN','CATALOG_EDITOR') or hasAuthority('SCOPE_product:brand:write')")
+    @Operation(summary = "Create brand", security = {@SecurityRequirement(name = "bearer-key")})
     public BrandResponse create(@RequestBody @Valid BrandCreateRequest req) {
         var b = brandCommands.create(req.name(), req.active());
         return DtoMapper.toDto(b);
@@ -36,6 +42,7 @@ public class BrandController {
 
     @PutMapping("/api/v1/admin/brands/{id}")
     @PreAuthorize("hasAnyRole('ADMIN','CATALOG_EDITOR') or hasAuthority('SCOPE_product:brand:write')")
+    @Operation(summary = "Update brand", security = {@SecurityRequirement(name = "bearer-key")})
     public BrandResponse update(@PathVariable UUID id, @RequestBody @Valid BrandUpdateRequest req) {
         var b = brandCommands.update(id, req.name(), req.active());
         return DtoMapper.toDto(b);
@@ -44,6 +51,7 @@ public class BrandController {
     @DeleteMapping("/api/v1/admin/brands/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PreAuthorize("hasAnyRole('ADMIN','CATALOG_EDITOR') or hasAuthority('SCOPE_product:brand:delete')")
+    @Operation(summary = "Delete brand", security = {@SecurityRequirement(name = "bearer-key")})
     public void delete(@PathVariable UUID id) {
         brandCommands.delete(id);
     }

--- a/catalog-service/src/main/java/com/example/catalog/web/category/CategoryController.java
+++ b/catalog-service/src/main/java/com/example/catalog/web/category/CategoryController.java
@@ -10,6 +10,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 
 import java.util.List;
 import java.util.UUID;
@@ -17,11 +20,13 @@ import java.util.UUID;
 @Validated
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "Categories")
 public class CategoryController {
     private final CategoryQueries categoryQueries;
     private final CategoryCommands categoryCommands;
 
     @GetMapping("/api/v1/catalog/categories")
+    @Operation(summary = "List categories")
     public List<CategoryResponse> categories(@RequestParam(required = false) Boolean active,
                                              @RequestParam(required = false) UUID parentId) {
         return categoryQueries.list(active, parentId).stream().map(DtoMapper::toDto).toList();
@@ -30,6 +35,7 @@ public class CategoryController {
     @PostMapping("/api/v1/admin/categories")
     @ResponseStatus(HttpStatus.CREATED)
     @PreAuthorize("hasAnyRole('ADMIN','CATALOG_EDITOR') or hasAuthority('SCOPE_product:category:write')")
+    @Operation(summary = "Create category", security = {@SecurityRequirement(name = "bearer-key")})
     public CategoryResponse create(@RequestBody @Valid CategoryCreateRequest req) {
         var c = categoryCommands.create(req.name(), req.parentId(), req.active(), req.sortOrder());
         return DtoMapper.toDto(c);
@@ -37,6 +43,7 @@ public class CategoryController {
 
     @PutMapping("/api/v1/admin/categories/{id}")
     @PreAuthorize("hasAnyRole('ADMIN','CATALOG_EDITOR') or hasAuthority('SCOPE_product:category:write')")
+    @Operation(summary = "Update category", security = {@SecurityRequirement(name = "bearer-key")})
     public CategoryResponse update(@PathVariable UUID id, @RequestBody @Valid CategoryUpdateRequest req) {
         var c = categoryCommands.update(id, req.name(), req.parentId(), req.active(), req.sortOrder());
         return DtoMapper.toDto(c);
@@ -45,6 +52,7 @@ public class CategoryController {
     @DeleteMapping("/api/v1/admin/categories/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PreAuthorize("hasAnyRole('ADMIN','CATALOG_EDITOR') or hasAuthority('SCOPE_product:category:delete')")
+    @Operation(summary = "Delete category", security = {@SecurityRequirement(name = "bearer-key")})
     public void delete(@PathVariable UUID id) {
         categoryCommands.delete(id);
     }

--- a/catalog-service/src/main/java/com/example/catalog/web/product/ProductController.java
+++ b/catalog-service/src/main/java/com/example/catalog/web/product/ProductController.java
@@ -15,17 +15,22 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 
 import java.util.UUID;
 
 @Validated
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "Products")
 public class ProductController {
     private final ProductQueries productQueries;
     private final ProductCommands productCommands;
 
     @GetMapping("/api/v1/catalog/products")
+    @Operation(summary = "Search products")
     public PageResult<ProductListItemResponse> products(@RequestParam(required = false) String q,
                                                         @RequestParam(required = false) UUID brandId,
                                                         @RequestParam(required = false) UUID categoryId,
@@ -39,6 +44,7 @@ public class ProductController {
     }
 
     @GetMapping("/api/v1/catalog/products/{slug}")
+    @Operation(summary = "Get product detail")
     public ProductDetailResponse productDetail(@PathVariable String slug) {
         return DtoMapper.toDetailDto(productQueries.getBySlug(slug));
     }
@@ -46,6 +52,7 @@ public class ProductController {
     @PostMapping("/api/v1/admin/products")
     @ResponseStatus(HttpStatus.CREATED)
     @PreAuthorize("hasAnyRole('ADMIN','CATALOG_EDITOR') or hasAuthority('SCOPE_product:product:write')")
+    @Operation(summary = "Create product", security = {@SecurityRequirement(name = "bearer-key")})
     public ProductDetailResponse create(@RequestBody @Valid ProductCreateRequest req) {
         var p = productCommands.create(req.name(), req.shortDesc(), req.brandId(), req.categoryId(), req.published());
         return DtoMapper.toDetailDto(p);
@@ -53,6 +60,7 @@ public class ProductController {
 
     @PutMapping("/api/v1/admin/products/{id}")
     @PreAuthorize("hasAnyRole('ADMIN','CATALOG_EDITOR') or hasAuthority('SCOPE_product:product:write')")
+    @Operation(summary = "Update product", security = {@SecurityRequirement(name = "bearer-key")})
     public ProductDetailResponse update(@PathVariable UUID id, @RequestBody @Valid ProductUpdateRequest req) {
         var p = productCommands.update(id, req.name(), req.shortDesc(), req.brandId(), req.categoryId(), req.published());
         return DtoMapper.toDetailDto(p);
@@ -61,6 +69,7 @@ public class ProductController {
     @DeleteMapping("/api/v1/admin/products/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PreAuthorize("hasAnyRole('ADMIN','CATALOG_EDITOR') or hasAuthority('SCOPE_product:product:delete')")
+    @Operation(summary = "Delete product", security = {@SecurityRequirement(name = "bearer-key")})
     public void delete(@PathVariable UUID id) {
         productCommands.delete(id);
     }

--- a/catalog-service/src/main/java/com/example/catalog/web/sku/SkuController.java
+++ b/catalog-service/src/main/java/com/example/catalog/web/sku/SkuController.java
@@ -10,17 +10,22 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 
 import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "Skus")
 public class SkuController {
     private final SkuCommands skuCommands;
 
     @PostMapping("/api/v1/admin/products/{productId}/skus")
     @ResponseStatus(HttpStatus.CREATED)
     @PreAuthorize("hasAnyRole('ADMIN','CATALOG_EDITOR') or hasAuthority('SCOPE_product:sku:write')")
+    @Operation(summary = "Create SKU", security = {@SecurityRequirement(name = "bearer-key")})
     public SkuResponse create(@PathVariable UUID productId, @RequestBody @Valid SkuCreateRequest req) {
         var s = skuCommands.create(productId, req.skuCode(), req.active(), req.barcode());
         return DtoMapper.toDto(s);
@@ -28,6 +33,7 @@ public class SkuController {
 
     @PutMapping("/api/v1/admin/skus/{id}")
     @PreAuthorize("hasAnyRole('ADMIN','CATALOG_EDITOR') or hasAuthority('SCOPE_product:sku:write')")
+    @Operation(summary = "Update SKU", security = {@SecurityRequirement(name = "bearer-key")})
     public SkuResponse update(@PathVariable UUID id, @RequestBody @Valid SkuUpdateRequest req) {
         var s = skuCommands.update(id, req.skuCode(), req.active(), req.barcode());
         return DtoMapper.toDto(s);
@@ -36,6 +42,7 @@ public class SkuController {
     @DeleteMapping("/api/v1/admin/skus/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PreAuthorize("hasAnyRole('ADMIN','CATALOG_EDITOR') or hasAuthority('SCOPE_product:sku:delete')")
+    @Operation(summary = "Delete SKU", security = {@SecurityRequirement(name = "bearer-key")})
     public void delete(@PathVariable UUID id) {
         skuCommands.delete(id);
     }

--- a/gateway-service/pom.xml
+++ b/gateway-service/pom.xml
@@ -31,6 +31,13 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
 
+        <!-- OpenAPI aggregator & UI -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webflux-ui</artifactId>
+            <version>${springdoc.version}</version>
+        </dependency>
+
         <!-- Common helper -->
         <dependency>
             <groupId>com.example</groupId>

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -52,6 +52,17 @@ spring:
           filters:
             - StripPrefix=1
 
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+    urls:
+      - name: auth
+        url: /auth/v3/api-docs
+      - name: iam
+        url: /iam/v3/api-docs
+      - name: catalog
+        url: /catalog/v3/api-docs
+
 eureka:
   client:
     service-url:

--- a/iam-service/pom.xml
+++ b/iam-service/pom.xml
@@ -35,6 +35,13 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
 
+        <!-- OpenAPI docs only (UI via gateway) -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-api</artifactId>
+            <version>${springdoc.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>

--- a/iam-service/src/main/java/com/example/iam/config/OpenApiConfig.java
+++ b/iam-service/src/main/java/com/example/iam/config/OpenApiConfig.java
@@ -1,0 +1,18 @@
+package com.example.iam.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.servers.Server;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+    info = @Info(title = "IAM API", version = "v1", description = "IAM service API"),
+    servers = @Server(url = "/iam")
+)
+@SecurityScheme(name = "bearer-key", type = SecuritySchemeType.HTTP, scheme = "bearer", bearerFormat = "JWT")
+public class OpenApiConfig {
+}
+

--- a/iam-service/src/main/java/com/example/iam/config/SecurityConfig.java
+++ b/iam-service/src/main/java/com/example/iam/config/SecurityConfig.java
@@ -41,8 +41,8 @@ public class SecurityConfig {
         http.csrf(AbstractHttpConfigurer::disable);
 
         http.authorizeHttpRequests(auth -> auth
-                // Actuator bebas
-                .requestMatchers("/actuator/health", "/actuator/info").permitAll()
+                // Actuator & OpenAPI bebas
+                .requestMatchers("/actuator/health", "/actuator/info", "/v3/api-docs/**").permitAll()
 
                 // INTERNAL API (dipanggil Auth-Service) → INTERNAL atau ADMIN
                 .requestMatchers("/internal/v1/**").hasAnyRole("INTERNAL","ADMIN")

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
         <nimbus.version>10.4.2</nimbus.version>
         <caffeine.version>3.1.8</caffeine.version>
         <reactor.netty.version>1.1.31</reactor.netty.version>
+        <springdoc.version>2.6.0</springdoc.version>
 
         <!-- Plugin versions -->
         <compiler.plugin.version>3.11.0</compiler.plugin.version>


### PR DESCRIPTION
## Summary
- unify `springdoc-openapi` version in parent pom
- expose only OpenAPI docs in services and aggregate Swagger UI via gateway
- configure gateway to serve Swagger UI at `/swagger-ui.html`
- point each service's OpenAPI server to its gateway route so Swagger calls go through the gateway

## Testing
- `mvn -pl gateway-service,auth-service,iam-service,catalog-service -am test`


------
https://chatgpt.com/codex/tasks/task_e_68b3ffe672e0832e82dfd4ef6accd256