### PR TITLE
Reduce Eureka client refresh intervals for faster detection

### DIFF
--- a/auth-service/src/main/resources/application.yml
+++ b/auth-service/src/main/resources/application.yml
@@ -69,3 +69,8 @@ eureka:
   client:
     service-url:
       defaultZone: http://localhost:8761/eureka/
+    registry-fetch-interval-seconds: 5         # default 30
+    initial-instance-info-replication-interval-seconds: 5  # default 40
+  instance:
+    lease-renewal-interval-in-seconds: 5       # default 30
+    lease-expiration-duration-in-seconds: 10   # default 90

--- a/catalog-service/src/main/resources/application.yml
+++ b/catalog-service/src/main/resources/application.yml
@@ -44,6 +44,11 @@ eureka:
   client:
     service-url:
       defaultZone: http://localhost:8761/eureka/
+    registry-fetch-interval-seconds: 5         # default 30
+    initial-instance-info-replication-interval-seconds: 5  # default 40
+  instance:
+    lease-renewal-interval-in-seconds: 5       # default 30
+    lease-expiration-duration-in-seconds: 10   # default 90
 
 iam:
   client:

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -67,6 +67,11 @@ eureka:
   client:
     service-url:
       defaultZone: http://localhost:8761/eureka/
+    registry-fetch-interval-seconds: 5         # default 30
+    initial-instance-info-replication-interval-seconds: 5  # default 40
+  instance:
+    lease-renewal-interval-in-seconds: 5       # default 30
+    lease-expiration-duration-in-seconds: 10   # default 90
 
 # health/info
 management:

--- a/iam-service/src/main/resources/application.yml
+++ b/iam-service/src/main/resources/application.yml
@@ -43,3 +43,8 @@ eureka:
   client:
     service-url:
       defaultZone: http://localhost:8761/eureka/
+    registry-fetch-interval-seconds: 5         # default 30
+    initial-instance-info-replication-interval-seconds: 5  # default 40
+  instance:
+    lease-renewal-interval-in-seconds: 5       # default 30
+    lease-expiration-duration-in-seconds: 10   # default 90

--- a/profile-service/src/main/resources/application.yml
+++ b/profile-service/src/main/resources/application.yml
@@ -1,0 +1,16 @@
+server:
+  port: 9300
+
+spring:
+  application:
+    name: profile-service
+
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:8761/eureka/
+    registry-fetch-interval-seconds: 5         # default 30
+    initial-instance-info-replication-interval-seconds: 5  # default 40
+  instance:
+    lease-renewal-interval-in-seconds: 5       # default 30
+    lease-expiration-duration-in-seconds: 10   # default 90


### PR DESCRIPTION
## Summary
- Reduce Eureka registry fetch and replication intervals to 5s across auth, catalog, iam, profile and gateway services
- Tighten instance lease renewal to 5s and expiration to 10s for faster failover
- Add missing profile-service application configuration

## Testing
- `mvn -q -pl auth-service,catalog-service,iam-service,gateway-service,profile-service test` *(fails: interrupted due to long runtime)*
- `curl -s http://localhost:8761/eureka/apps | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68b47903d6d4832e99ff8a734fdfca21