### PR TITLE
Add operationId and numeric Swagger tag ordering

### DIFF
--- a/catalog-service/src/main/java/com/example/catalog/web/PingController.java
+++ b/catalog-service/src/main/java/com/example/catalog/web/PingController.java
@@ -17,23 +17,23 @@ import java.util.Map;
 @Validated
 @RestController
 @RequestMapping("/api/v1")
-@Tag(name = "Ping")
+@Tag(name = "0. System")
 public class PingController {
 
     @GetMapping("/ping")
-    @Operation(summary = "Simple ping")
+    @Operation(operationId = "ping_1_ping", summary = "Simple ping")
     public ResponseEntity<?> ping() {
         return ResponseEntity.ok(Map.of("message", "pong"));
     }
 
     @GetMapping("/secure")
-    @Operation(summary = "Secured ping", security = {@SecurityRequirement(name = "bearer-key")})
+    @Operation(operationId = "ping_2_secure", summary = "Secured ping", security = {@SecurityRequirement(name = "bearer-key")})
     public ResponseEntity<?> secure() {
         return ResponseEntity.ok(Map.of("message", "secured"));
     }
 
     @PostMapping("/echo")
-    @Operation(summary = "Echo text", security = {@SecurityRequirement(name = "bearer-key")})
+    @Operation(operationId = "ping_3_echo", summary = "Echo text", security = {@SecurityRequirement(name = "bearer-key")})
     public ResponseEntity<?> echo(@RequestParam @NotBlank String text) {
         return ResponseEntity.ok(Map.of("echo", text));
     }

--- a/catalog-service/src/main/java/com/example/catalog/web/brand/BrandController.java
+++ b/catalog-service/src/main/java/com/example/catalog/web/brand/BrandController.java
@@ -20,13 +20,13 @@ import java.util.UUID;
 @Validated
 @RestController
 @RequiredArgsConstructor
-@Tag(name = "Brands")
+@Tag(name = "1. Brand")
 public class BrandController {
     private final BrandQueries brandQueries;
     private final BrandCommands brandCommands;
 
     @GetMapping("/api/v1/catalog/brands")
-    @Operation(summary = "List brands")
+    @Operation(operationId = "brand_1_list", summary = "List brands")
     public List<BrandResponse> brands(@RequestParam(required = false) Boolean active) {
         return brandQueries.list(active).stream().map(DtoMapper::toDto).toList();
     }
@@ -34,7 +34,7 @@ public class BrandController {
     @PostMapping("/api/v1/admin/brands")
     @ResponseStatus(HttpStatus.CREATED)
     @PreAuthorize("hasAnyRole('ADMIN','CATALOG_EDITOR') or hasAuthority('SCOPE_product:brand:write')")
-    @Operation(summary = "Create brand", security = {@SecurityRequirement(name = "bearer-key")})
+    @Operation(operationId = "brand_2_create", summary = "Create brand", security = {@SecurityRequirement(name = "bearer-key")})
     public BrandResponse create(@RequestBody @Valid BrandCreateRequest req) {
         var b = brandCommands.create(req.name(), req.active());
         return DtoMapper.toDto(b);
@@ -42,7 +42,7 @@ public class BrandController {
 
     @PutMapping("/api/v1/admin/brands/{id}")
     @PreAuthorize("hasAnyRole('ADMIN','CATALOG_EDITOR') or hasAuthority('SCOPE_product:brand:write')")
-    @Operation(summary = "Update brand", security = {@SecurityRequirement(name = "bearer-key")})
+    @Operation(operationId = "brand_3_update", summary = "Update brand", security = {@SecurityRequirement(name = "bearer-key")})
     public BrandResponse update(@PathVariable UUID id, @RequestBody @Valid BrandUpdateRequest req) {
         var b = brandCommands.update(id, req.name(), req.active());
         return DtoMapper.toDto(b);
@@ -51,7 +51,7 @@ public class BrandController {
     @DeleteMapping("/api/v1/admin/brands/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PreAuthorize("hasAnyRole('ADMIN','CATALOG_EDITOR') or hasAuthority('SCOPE_product:brand:delete')")
-    @Operation(summary = "Delete brand", security = {@SecurityRequirement(name = "bearer-key")})
+    @Operation(operationId = "brand_4_delete", summary = "Delete brand", security = {@SecurityRequirement(name = "bearer-key")})
     public void delete(@PathVariable UUID id) {
         brandCommands.delete(id);
     }

--- a/catalog-service/src/main/java/com/example/catalog/web/category/CategoryController.java
+++ b/catalog-service/src/main/java/com/example/catalog/web/category/CategoryController.java
@@ -20,13 +20,13 @@ import java.util.UUID;
 @Validated
 @RestController
 @RequiredArgsConstructor
-@Tag(name = "Categories")
+@Tag(name = "2. Category")
 public class CategoryController {
     private final CategoryQueries categoryQueries;
     private final CategoryCommands categoryCommands;
 
     @GetMapping("/api/v1/catalog/categories")
-    @Operation(summary = "List categories")
+    @Operation(operationId = "category_1_list", summary = "List categories")
     public List<CategoryResponse> categories(@RequestParam(required = false) Boolean active,
                                              @RequestParam(required = false) UUID parentId) {
         return categoryQueries.list(active, parentId).stream().map(DtoMapper::toDto).toList();
@@ -35,7 +35,7 @@ public class CategoryController {
     @PostMapping("/api/v1/admin/categories")
     @ResponseStatus(HttpStatus.CREATED)
     @PreAuthorize("hasAnyRole('ADMIN','CATALOG_EDITOR') or hasAuthority('SCOPE_product:category:write')")
-    @Operation(summary = "Create category", security = {@SecurityRequirement(name = "bearer-key")})
+    @Operation(operationId = "category_2_create", summary = "Create category", security = {@SecurityRequirement(name = "bearer-key")})
     public CategoryResponse create(@RequestBody @Valid CategoryCreateRequest req) {
         var c = categoryCommands.create(req.name(), req.parentId(), req.active(), req.sortOrder());
         return DtoMapper.toDto(c);
@@ -43,7 +43,7 @@ public class CategoryController {
 
     @PutMapping("/api/v1/admin/categories/{id}")
     @PreAuthorize("hasAnyRole('ADMIN','CATALOG_EDITOR') or hasAuthority('SCOPE_product:category:write')")
-    @Operation(summary = "Update category", security = {@SecurityRequirement(name = "bearer-key")})
+    @Operation(operationId = "category_3_update", summary = "Update category", security = {@SecurityRequirement(name = "bearer-key")})
     public CategoryResponse update(@PathVariable UUID id, @RequestBody @Valid CategoryUpdateRequest req) {
         var c = categoryCommands.update(id, req.name(), req.parentId(), req.active(), req.sortOrder());
         return DtoMapper.toDto(c);
@@ -52,7 +52,7 @@ public class CategoryController {
     @DeleteMapping("/api/v1/admin/categories/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PreAuthorize("hasAnyRole('ADMIN','CATALOG_EDITOR') or hasAuthority('SCOPE_product:category:delete')")
-    @Operation(summary = "Delete category", security = {@SecurityRequirement(name = "bearer-key")})
+    @Operation(operationId = "category_4_delete", summary = "Delete category", security = {@SecurityRequirement(name = "bearer-key")})
     public void delete(@PathVariable UUID id) {
         categoryCommands.delete(id);
     }

--- a/catalog-service/src/main/java/com/example/catalog/web/product/ProductController.java
+++ b/catalog-service/src/main/java/com/example/catalog/web/product/ProductController.java
@@ -24,13 +24,13 @@ import java.util.UUID;
 @Validated
 @RestController
 @RequiredArgsConstructor
-@Tag(name = "Products")
+@Tag(name = "3. Product")
 public class ProductController {
     private final ProductQueries productQueries;
     private final ProductCommands productCommands;
 
     @GetMapping("/api/v1/catalog/products")
-    @Operation(summary = "Search products")
+    @Operation(operationId = "product_1_search", summary = "Search products")
     public PageResult<ProductListItemResponse> products(@RequestParam(required = false) String q,
                                                         @RequestParam(required = false) UUID brandId,
                                                         @RequestParam(required = false) UUID categoryId,
@@ -44,7 +44,7 @@ public class ProductController {
     }
 
     @GetMapping("/api/v1/catalog/products/{slug}")
-    @Operation(summary = "Get product detail")
+    @Operation(operationId = "product_2_detail", summary = "Get product detail")
     public ProductDetailResponse productDetail(@PathVariable String slug) {
         return DtoMapper.toDetailDto(productQueries.getBySlug(slug));
     }
@@ -52,7 +52,7 @@ public class ProductController {
     @PostMapping("/api/v1/admin/products")
     @ResponseStatus(HttpStatus.CREATED)
     @PreAuthorize("hasAnyRole('ADMIN','CATALOG_EDITOR') or hasAuthority('SCOPE_product:product:write')")
-    @Operation(summary = "Create product", security = {@SecurityRequirement(name = "bearer-key")})
+    @Operation(operationId = "product_3_create", summary = "Create product", security = {@SecurityRequirement(name = "bearer-key")})
     public ProductDetailResponse create(@RequestBody @Valid ProductCreateRequest req) {
         var p = productCommands.create(req.name(), req.shortDesc(), req.brandId(), req.categoryId(), req.published());
         return DtoMapper.toDetailDto(p);
@@ -60,7 +60,7 @@ public class ProductController {
 
     @PutMapping("/api/v1/admin/products/{id}")
     @PreAuthorize("hasAnyRole('ADMIN','CATALOG_EDITOR') or hasAuthority('SCOPE_product:product:write')")
-    @Operation(summary = "Update product", security = {@SecurityRequirement(name = "bearer-key")})
+    @Operation(operationId = "product_4_update", summary = "Update product", security = {@SecurityRequirement(name = "bearer-key")})
     public ProductDetailResponse update(@PathVariable UUID id, @RequestBody @Valid ProductUpdateRequest req) {
         var p = productCommands.update(id, req.name(), req.shortDesc(), req.brandId(), req.categoryId(), req.published());
         return DtoMapper.toDetailDto(p);
@@ -69,7 +69,7 @@ public class ProductController {
     @DeleteMapping("/api/v1/admin/products/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PreAuthorize("hasAnyRole('ADMIN','CATALOG_EDITOR') or hasAuthority('SCOPE_product:product:delete')")
-    @Operation(summary = "Delete product", security = {@SecurityRequirement(name = "bearer-key")})
+    @Operation(operationId = "product_5_delete", summary = "Delete product", security = {@SecurityRequirement(name = "bearer-key")})
     public void delete(@PathVariable UUID id) {
         productCommands.delete(id);
     }

--- a/catalog-service/src/main/java/com/example/catalog/web/sku/SkuController.java
+++ b/catalog-service/src/main/java/com/example/catalog/web/sku/SkuController.java
@@ -18,14 +18,14 @@ import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
-@Tag(name = "Skus")
+@Tag(name = "4. Sku")
 public class SkuController {
     private final SkuCommands skuCommands;
 
     @PostMapping("/api/v1/admin/products/{productId}/skus")
     @ResponseStatus(HttpStatus.CREATED)
     @PreAuthorize("hasAnyRole('ADMIN','CATALOG_EDITOR') or hasAuthority('SCOPE_product:sku:write')")
-    @Operation(summary = "Create SKU", security = {@SecurityRequirement(name = "bearer-key")})
+    @Operation(operationId = "sku_1_create", summary = "Create SKU", security = {@SecurityRequirement(name = "bearer-key")})
     public SkuResponse create(@PathVariable UUID productId, @RequestBody @Valid SkuCreateRequest req) {
         var s = skuCommands.create(productId, req.skuCode(), req.active(), req.barcode());
         return DtoMapper.toDto(s);
@@ -33,7 +33,7 @@ public class SkuController {
 
     @PutMapping("/api/v1/admin/skus/{id}")
     @PreAuthorize("hasAnyRole('ADMIN','CATALOG_EDITOR') or hasAuthority('SCOPE_product:sku:write')")
-    @Operation(summary = "Update SKU", security = {@SecurityRequirement(name = "bearer-key")})
+    @Operation(operationId = "sku_2_update", summary = "Update SKU", security = {@SecurityRequirement(name = "bearer-key")})
     public SkuResponse update(@PathVariable UUID id, @RequestBody @Valid SkuUpdateRequest req) {
         var s = skuCommands.update(id, req.skuCode(), req.active(), req.barcode());
         return DtoMapper.toDto(s);
@@ -42,7 +42,7 @@ public class SkuController {
     @DeleteMapping("/api/v1/admin/skus/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PreAuthorize("hasAnyRole('ADMIN','CATALOG_EDITOR') or hasAuthority('SCOPE_product:sku:delete')")
-    @Operation(summary = "Delete SKU", security = {@SecurityRequirement(name = "bearer-key")})
+    @Operation(operationId = "sku_3_delete", summary = "Delete SKU", security = {@SecurityRequirement(name = "bearer-key")})
     public void delete(@PathVariable UUID id) {
         skuCommands.delete(id);
     }

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -54,6 +54,8 @@ spring:
 
 springdoc:
   swagger-ui:
+    operations-sorter: alpha
+    tags-sorter: alpha
     path: /swagger-ui.html
     urls:
       - name: auth


### PR DESCRIPTION
## Summary
- add `tags-sorter: alpha` in gateway Swagger UI config
- add `operations-sorter: alpha` in gateway Swagger UI config
- provide explicit `operationId` values for catalog endpoints
- prefix catalog Swagger tags with numbers to reflect business dependencies

## Testing
- `mvn -pl catalog-service,gateway-service -am test | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68b47c372068832e89b9b00ac663728f