### PR TITLE
Centralize springdoc dependency version

### DIFF
--- a/auth-service/pom.xml
+++ b/auth-service/pom.xml
@@ -69,7 +69,6 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-api</artifactId>
-            <version>${springdoc.version}</version>
         </dependency>
 
         <!-- Resilience4j -->

--- a/catalog-service/pom.xml
+++ b/catalog-service/pom.xml
@@ -39,7 +39,6 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-api</artifactId>
-            <version>${springdoc.version}</version>
         </dependency>
 
         <!-- Data JPA + PostgreSQL -->

--- a/iam-service/pom.xml
+++ b/iam-service/pom.xml
@@ -39,7 +39,6 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-api</artifactId>
-            <version>${springdoc.version}</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,13 @@
                 <artifactId>caffeine</artifactId>
                 <version>${caffeine.version}</version>
             </dependency>
+
+            <!-- SpringDoc OpenAPI -->
+            <dependency>
+                <groupId>org.springdoc</groupId>
+                <artifactId>springdoc-openapi-starter-webmvc-api</artifactId>
+                <version>${springdoc.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
## Summary
- Add `springdoc-openapi-starter-webmvc-api` to parent `dependencyManagement`
- Rely on parent-managed version for service modules

## Testing
- `mvn -pl auth-service,catalog-service,iam-service -am test`
- `mvn -pl auth-service,catalog-service,iam-service -am -DskipTests package`


------
https://chatgpt.com/codex/tasks/task_e_68b5a478e84c832ebc2608732854550b