### PR TITLE
[iam][auth] Document IAM and auth APIs with OpenAPI tags

### DIFF
--- a/auth-service/src/main/java/com/example/auth/web/AuthController.java
+++ b/auth-service/src/main/java/com/example/auth/web/AuthController.java
@@ -6,6 +6,8 @@ import com.example.auth.web.dto.LoginRequest;
 import com.example.auth.web.dto.RefreshRequest;
 import com.example.auth.web.dto.RegisterRequest;
 import com.example.auth.web.dto.TokenResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -19,12 +21,14 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
+@Tag(name = "1. Auth")
 public class AuthController {
 
     private final AuthCommands authCommands;
     private final AccountCommands accountCommands;
 
     @PostMapping("/register")
+    @Operation(operationId = "auth_1_register", summary = "Register account")
     public ResponseEntity<Map<String, Object>> register(@Valid @RequestBody RegisterRequest req) {
         UUID id = accountCommands.register(req.getUsername(), req.getEmail(), req.getPassword());
         return ResponseEntity.created(URI.create("/accounts/" + id))
@@ -32,6 +36,7 @@ public class AuthController {
     }
 
     @PostMapping("/login")
+    @Operation(operationId = "auth_2_login", summary = "Login")
     public ResponseEntity<TokenResponse> login(@Validated @RequestBody LoginRequest req) {
         AuthCommands.TokenPair pair = authCommands.login(req.getUsernameOrEmail(), req.getPassword());
         TokenResponse body = new TokenResponse(pair.tokenType(), pair.accessToken(), pair.expiresIn(), pair.refreshToken());
@@ -39,6 +44,7 @@ public class AuthController {
     }
 
     @PostMapping("/refresh")
+    @Operation(operationId = "auth_3_refresh", summary = "Refresh token")
     public ResponseEntity<TokenResponse> refresh(@Validated @RequestBody RefreshRequest req) {
         AuthCommands.TokenPair pair = authCommands.refresh(req.getRefreshToken());
         TokenResponse body = new TokenResponse(pair.tokenType(), pair.accessToken(), pair.expiresIn(), pair.refreshToken());

--- a/auth-service/src/main/java/com/example/auth/web/JwksController.java
+++ b/auth-service/src/main/java/com/example/auth/web/JwksController.java
@@ -1,6 +1,8 @@
 package com.example.auth.web;
 
 import com.example.auth.application.jwk.JwkQueries;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
@@ -9,10 +11,12 @@ import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "2. JWK")
 public class JwksController {
     private final JwkQueries jwkQueries;
 
     @GetMapping(value="/.well-known/jwks.json", produces = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(operationId = "jwk_1_keys", summary = "Get JWKS")
     public Map<String,Object> jwks() {
         return jwkQueries.jwks();
     }

--- a/iam-service/src/main/java/com/example/iam/web/AssignmentController.java
+++ b/iam-service/src/main/java/com/example/iam/web/AssignmentController.java
@@ -1,6 +1,9 @@
 package com.example.iam.web;
 
 import com.example.iam.application.assignment.AssignmentCommands;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -10,28 +13,33 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/api/v1/assign")
 @RequiredArgsConstructor
+@Tag(name = "3. Assignment")
 public class AssignmentController {
     private final AssignmentCommands commands;
 
     @PostMapping("/role/{roleId}/permission/{permissionId}")
+    @Operation(operationId = "assignment_1_add_permission_to_role", summary = "Add permission to role", security = {@SecurityRequirement(name = "bearer-key")})
     public Map<String, String> addPermissionToRole(@PathVariable Long roleId, @PathVariable Long permissionId) {
         commands.assignPermissionToRole(roleId, permissionId);
         return Map.of("message","ok");
     }
 
     @DeleteMapping("/role/{roleId}/permission/{permissionId}")
+    @Operation(operationId = "assignment_2_remove_permission_from_role", summary = "Remove permission from role", security = {@SecurityRequirement(name = "bearer-key")})
     public Map<String, String> removePermissionFromRole(@PathVariable Long roleId, @PathVariable Long permissionId) {
         commands.removePermissionFromRole(roleId, permissionId);
         return Map.of("message","ok");
     }
 
     @PostMapping("/user/{accountId}/role/{roleId}")
+    @Operation(operationId = "assignment_3_add_role_to_user", summary = "Add role to user", security = {@SecurityRequirement(name = "bearer-key")})
     public Map<String, String> addRoleToUser(@PathVariable UUID accountId, @PathVariable Long roleId) {
         commands.assignRoleToUser(accountId, roleId);
         return Map.of("message","ok");
     }
 
     @DeleteMapping("/user/{accountId}/role/{roleId}")
+    @Operation(operationId = "assignment_4_remove_role_from_user", summary = "Remove role from user", security = {@SecurityRequirement(name = "bearer-key")})
     public Map<String, String> removeRoleFromUser(@PathVariable UUID accountId, @PathVariable Long roleId) {
         commands.removeRoleFromUser(accountId, roleId);
         return Map.of("message","ok");

--- a/iam-service/src/main/java/com/example/iam/web/AuthzController.java
+++ b/iam-service/src/main/java/com/example/iam/web/AuthzController.java
@@ -2,6 +2,9 @@ package com.example.iam.web;
 
 import com.example.iam.application.entitlement.EntitlementQueries;
 import com.example.iam.web.dto.AuthzCheckRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -11,10 +14,12 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/v1/authz")
 @RequiredArgsConstructor
+@Tag(name = "5. Authorization")
 public class AuthzController {
     private final EntitlementQueries queries;
 
     @PostMapping("/check")
+    @Operation(operationId = "authz_1_check", summary = "Check authorization", security = {@SecurityRequirement(name = "bearer-key")})
     public Map<String, Object> check(@Valid @RequestBody AuthzCheckRequest req) {
         return queries.checkAuthorization(req.getSub(), req.getAction());
     }

--- a/iam-service/src/main/java/com/example/iam/web/EntitlementController.java
+++ b/iam-service/src/main/java/com/example/iam/web/EntitlementController.java
@@ -1,6 +1,9 @@
 package com.example.iam.web;
 
 import com.example.iam.application.entitlement.EntitlementQueries;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -10,10 +13,12 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/internal/v1/entitlements")
 @RequiredArgsConstructor
+@Tag(name = "4. Entitlement")
 public class EntitlementController {
     private final EntitlementQueries queries;
 
     @GetMapping("/{accountId}")
+    @Operation(operationId = "entitlement_1_get", summary = "Get entitlements", security = {@SecurityRequirement(name = "bearer-key")})
     public Map<String, Object> getEntitlements(@PathVariable UUID accountId) {
         return queries.getEntitlements(accountId);
     }

--- a/iam-service/src/main/java/com/example/iam/web/PermissionController.java
+++ b/iam-service/src/main/java/com/example/iam/web/PermissionController.java
@@ -4,6 +4,9 @@ import com.example.iam.application.permission.PermissionCommands;
 import com.example.iam.application.permission.PermissionQueries;
 import com.example.iam.domain.permission.Permission;
 import com.example.iam.web.dto.PermissionRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -13,26 +16,32 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/permissions")
 @RequiredArgsConstructor
+@Tag(name = "1. Permission")
 public class PermissionController {
     private final PermissionCommands commands;
     private final PermissionQueries queries;
 
     @GetMapping
+    @Operation(operationId = "permission_1_list", summary = "List permissions", security = {@SecurityRequirement(name = "bearer-key")})
     public List<Permission> all() { return queries.list(); }
 
     @GetMapping("/{id}")
+    @Operation(operationId = "permission_2_get", summary = "Get permission", security = {@SecurityRequirement(name = "bearer-key")})
     public Permission get(@PathVariable Long id) { return queries.getById(id); }
 
     @PostMapping
+    @Operation(operationId = "permission_3_create", summary = "Create permission", security = {@SecurityRequirement(name = "bearer-key")})
     public Permission create(@Valid @RequestBody PermissionRequest req) {
         return commands.create(req.getName(), req.getDescription());
     }
 
     @PutMapping("/{id}")
+    @Operation(operationId = "permission_4_update", summary = "Update permission", security = {@SecurityRequirement(name = "bearer-key")})
     public Permission update(@PathVariable Long id, @Valid @RequestBody PermissionRequest req) {
         return commands.update(id, req.getName(), req.getDescription());
     }
 
     @DeleteMapping("/{id}")
+    @Operation(operationId = "permission_5_delete", summary = "Delete permission", security = {@SecurityRequirement(name = "bearer-key")})
     public void delete(@PathVariable Long id) { commands.delete(id); }
 }

--- a/iam-service/src/main/java/com/example/iam/web/RoleController.java
+++ b/iam-service/src/main/java/com/example/iam/web/RoleController.java
@@ -4,6 +4,9 @@ import com.example.iam.application.role.RoleCommands;
 import com.example.iam.application.role.RoleQueries;
 import com.example.iam.domain.role.Role;
 import com.example.iam.web.dto.RoleRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -13,24 +16,30 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/roles")
 @RequiredArgsConstructor
+@Tag(name = "2. Role")
 public class RoleController {
     private final RoleCommands commands;
     private final RoleQueries queries;
 
     @GetMapping
+    @Operation(operationId = "role_1_list", summary = "List roles", security = {@SecurityRequirement(name = "bearer-key")})
     public List<Role> all() { return queries.list(); }
 
     @GetMapping("/{id}")
+    @Operation(operationId = "role_2_get", summary = "Get role", security = {@SecurityRequirement(name = "bearer-key")})
     public Role get(@PathVariable Long id) { return queries.getById(id); }
 
     @PostMapping
+    @Operation(operationId = "role_3_create", summary = "Create role", security = {@SecurityRequirement(name = "bearer-key")})
     public Role create(@Valid @RequestBody RoleRequest req) { return commands.create(req.getName()); }
 
     @PutMapping("/{id}")
+    @Operation(operationId = "role_4_update", summary = "Update role", security = {@SecurityRequirement(name = "bearer-key")})
     public Role update(@PathVariable Long id, @Valid @RequestBody RoleRequest req) {
         return commands.update(id, req.getName());
     }
 
     @DeleteMapping("/{id}")
+    @Operation(operationId = "role_5_delete", summary = "Delete role", security = {@SecurityRequirement(name = "bearer-key")})
     public void delete(@PathVariable Long id) { commands.delete(id); }
 }

--- a/iam-service/src/main/java/com/example/iam/web/UserQueryController.java
+++ b/iam-service/src/main/java/com/example/iam/web/UserQueryController.java
@@ -1,6 +1,9 @@
 package com.example.iam.web;
 
 import com.example.iam.application.user.UserQueries;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -10,10 +13,12 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/internal/v1/users")
 @RequiredArgsConstructor
+@Tag(name = "6. User")
 public class UserQueryController {
     private final UserQueries queries;
 
     @GetMapping("/{accountId}/roles")
+    @Operation(operationId = "user_1_get_roles", summary = "Get user roles", security = {@SecurityRequirement(name = "bearer-key")})
     public List<String> getRoles(@PathVariable UUID accountId) {
         return queries.getUserRoleNames(accountId);
     }


### PR DESCRIPTION
## Summary
- add numbered OpenAPI `@Tag` annotations for IAM and Auth controllers
- define ordered `@Operation` IDs and summaries to guide sequential usage

## Testing
- `mvn -pl auth-service,iam-service -am test`


------
https://chatgpt.com/codex/tasks/task_e_68b5aa22327c832ea50822dd08b57845