### PR TITLE
feat(iam,auth): expose user roles and listing endpoints

### DIFF
--- a/auth-service/src/main/java/com/example/auth/application/account/AccountQueries.java
+++ b/auth-service/src/main/java/com/example/auth/application/account/AccountQueries.java
@@ -1,0 +1,9 @@
+package com.example.auth.application.account;
+
+import com.example.auth.domain.account.Account;
+
+import java.util.List;
+
+public interface AccountQueries {
+    List<Account> list();
+}

--- a/auth-service/src/main/java/com/example/auth/application/account/AccountQueryService.java
+++ b/auth-service/src/main/java/com/example/auth/application/account/AccountQueryService.java
@@ -1,0 +1,17 @@
+package com.example.auth.application.account;
+
+import com.example.auth.domain.account.Account;
+import com.example.auth.domain.account.AccountRepository;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class AccountQueryService implements AccountQueries {
+    private final AccountRepository accountRepository;
+
+    @Override
+    public List<Account> list() {
+        return accountRepository.findAll();
+    }
+}

--- a/auth-service/src/main/java/com/example/auth/config/BeanConfig.java
+++ b/auth-service/src/main/java/com/example/auth/config/BeanConfig.java
@@ -2,6 +2,8 @@ package com.example.auth.config;
 
 import com.example.auth.application.account.AccountCommandService;
 import com.example.auth.application.account.AccountCommands;
+import com.example.auth.application.account.AccountQueries;
+import com.example.auth.application.account.AccountQueryService;
 import com.example.auth.application.auth.AuthCommandService;
 import com.example.auth.application.auth.AuthCommands;
 import com.example.auth.application.jwk.JwkQueries;
@@ -91,6 +93,12 @@ public class BeanConfig {
     public AccountCommands accountCommands(AccountRepository accountRepository,
                                            PasswordHasher passwordHasher) {
         return new AccountCommandService(accountRepository, passwordHasher);
+    }
+
+    // ---- Account slice (queries) ----
+    @Bean
+    public AccountQueries accountQueries(AccountRepository accountRepository) {
+        return new AccountQueryService(accountRepository);
     }
 
     // ---- Auth slice (commands) ----

--- a/auth-service/src/main/java/com/example/auth/domain/account/AccountRepository.java
+++ b/auth-service/src/main/java/com/example/auth/domain/account/AccountRepository.java
@@ -2,6 +2,7 @@ package com.example.auth.domain.account;
 
 import java.util.Optional;
 import java.util.UUID;
+import java.util.List;
 
 public interface AccountRepository {
     Optional<Account> findById(UUID id);
@@ -9,4 +10,5 @@ public interface AccountRepository {
     Optional<Account> findByEmail(String email);
     Optional<Account> findByUsernameOrEmail(String usernameOrEmail);
     Account save(Account account);
+    List<Account> findAll();
 }

--- a/auth-service/src/main/java/com/example/auth/infrastructure/jpa/AccountRepositoryImpl.java
+++ b/auth-service/src/main/java/com/example/auth/infrastructure/jpa/AccountRepositoryImpl.java
@@ -7,6 +7,7 @@ import com.example.auth.infrastructure.jpa.repository.JpaAccountRepository;
 
 import java.util.Optional;
 import java.util.UUID;
+import java.util.List;
 
 /**
  * Adapter JPA → Domain: AccountRepositoryImpl
@@ -44,5 +45,10 @@ public class AccountRepositoryImpl implements AccountRepository {
     @Override
     public Optional<Account> findById(UUID id) {
         return repo.findById(id).map(JpaMapper::toDomain);
+    }
+
+    @Override
+    public List<Account> findAll() {
+        return repo.findAll().stream().map(JpaMapper::toDomain).toList();
     }
 }

--- a/auth-service/src/main/java/com/example/auth/web/UserController.java
+++ b/auth-service/src/main/java/com/example/auth/web/UserController.java
@@ -1,0 +1,24 @@
+package com.example.auth.web;
+
+import com.example.auth.application.account.AccountQueries;
+import com.example.auth_service.web.api.UserApi;
+import com.example.auth_service.web.model.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class UserController implements UserApi {
+    private final AccountQueries accountQueries;
+
+    @Override
+    public ResponseEntity<List<User>> listUsers() {
+        List<User> body = accountQueries.list().stream()
+                .map(a -> new User().id(a.getId()).username(a.getUsername()))
+                .toList();
+        return ResponseEntity.ok(body);
+    }
+}

--- a/auth-service/src/test/java/com/example/auth/web/UserControllerTest.java
+++ b/auth-service/src/test/java/com/example/auth/web/UserControllerTest.java
@@ -1,0 +1,46 @@
+package com.example.auth.web;
+
+import com.example.auth.application.account.AccountQueries;
+import com.example.auth.config.CommonWebConfig;
+import com.example.auth.domain.account.Account;
+import jakarta.annotation.Resource;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = UserController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(CommonWebConfig.class)
+@ActiveProfiles("test")
+class UserControllerTest {
+
+    @Resource MockMvc mvc;
+    @MockBean AccountQueries accountQueries;
+
+    @Test
+    void listUsers_ok() throws Exception {
+        var a1 = Account.of(UUID.randomUUID(), "alice", "a@x.io", "h", "ACTIVE", OffsetDateTime.now(ZoneOffset.UTC));
+        var a2 = Account.of(UUID.randomUUID(), "bob", "b@x.io", "h", "ACTIVE", OffsetDateTime.now(ZoneOffset.UTC));
+        when(accountQueries.list()).thenReturn(List.of(a1, a2));
+
+        mvc.perform(get("/auth/api/v1/users"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(a1.getId().toString()))
+                .andExpect(jsonPath("$[0].username").value("alice"))
+                .andExpect(jsonPath("$[1].id").value(a2.getId().toString()))
+                .andExpect(jsonPath("$[1].username").value("bob"));
+    }
+}

--- a/docs/openapi/auth.yaml
+++ b/docs/openapi/auth.yaml
@@ -78,6 +78,21 @@ paths:
               schema: { $ref: '#/components/schemas/AccessTokenResponse' }
         '401': { description: Unauthorized, content: { application/json: { schema: { $ref: '#/components/schemas/ApiError' } } } }
 
+  /auth/api/v1/users:
+    get:
+      tags: [User]
+      operationId: listUsers
+      summary: List users
+      security: [ { cookieAuth: [] } ]
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/User' }
+
   /auth/api/v1/logout:
     post:
       tags: [Auth]
@@ -92,6 +107,11 @@ paths:
               schema: { type: string }
 
 components:
+  securitySchemes:
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: refresh_token
   schemas:
     RegisterRequest:
       type: object
@@ -118,6 +138,12 @@ components:
         accessToken: { type: string }
         expiresIn: { type: integer, format: int64 }
       required: [tokenType, accessToken, expiresIn]
+    User:
+      type: object
+      properties:
+        id: { type: string, format: uuid }
+        username: { type: string }
+      required: [id, username]
     ApiError:
       type: object
       properties:

--- a/docs/openapi/iam.yaml
+++ b/docs/openapi/iam.yaml
@@ -250,6 +250,21 @@ paths:
       responses:
         '200': { description: OK, content: { application/json: { schema: { type: object } } } }
 
+  /iam/api/v1/users/{accountId}/roles:
+    parameters:
+      - in: path
+        name: accountId
+        required: true
+        schema: { type: string, format: uuid }
+    get:
+      tags: [User]
+      operationId: getUserRolesPublic
+      summary: Get user roles
+      description: Requires ROLE_ADMIN.
+      security: [ { cookieAuth: [] } ]
+      responses:
+        '200': { description: OK, content: { application/json: { schema: { type: array, items: { type: string } } } } }
+
   /iam/internal/v1/users/{accountId}/roles:
     parameters:
       - in: path

--- a/iam-service/src/main/java/com/example/iam/config/SecurityConfig.java
+++ b/iam-service/src/main/java/com/example/iam/config/SecurityConfig.java
@@ -58,6 +58,9 @@ public class SecurityConfig {
                 // Current user info
                 .requestMatchers(HttpMethod.GET, "/iam/api/v1/users/me").authenticated()
 
+                // public user roles lookup
+                .requestMatchers(HttpMethod.GET, "/iam/api/v1/users/*/roles").hasRole("ADMIN")
+
                 // sisanya tutup
                 .anyRequest().denyAll()
         );

--- a/iam-service/src/main/java/com/example/iam/web/UserController.java
+++ b/iam-service/src/main/java/com/example/iam/web/UserController.java
@@ -73,5 +73,10 @@ public class UserController implements UserApi {
     public ResponseEntity<java.util.List<String>> getUserRoles(java.util.UUID accountId) {
         return ResponseEntity.ok(userQueries.getUserRoleNames(accountId));
     }
+
+    @Override
+    public ResponseEntity<java.util.List<String>> getUserRolesPublic(java.util.UUID accountId) {
+        return ResponseEntity.ok(userQueries.getUserRoleNames(accountId));
+    }
 }
 

--- a/iam-service/src/test/java/com/example/iam/web/UserQueryControllerTest.java
+++ b/iam-service/src/test/java/com/example/iam/web/UserQueryControllerTest.java
@@ -5,9 +5,16 @@ import com.example.iam.application.entitlement.EntitlementQueries;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.web.servlet.MockMvc;
+import com.example.common.web.response.ErrorProps;
+import com.example.common.web.response.ErrorResponseBuilder;
 
 import java.util.List;
 import java.util.UUID;
@@ -17,8 +24,33 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(controllers = UserController.class)
-@Import({GlobalExceptionHandler.class, WebTestConfig.class})
+@Import({GlobalExceptionHandler.class, UserQueryControllerTest.TestConfig.class})
 class UserQueryControllerTest {
+
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        ErrorProps errorProps() {
+            var p = new ErrorProps();
+            p.setVerbose(false);
+            return p;
+        }
+
+        @Bean
+        ErrorResponseBuilder errorResponseBuilder(ErrorProps props) {
+            return new ErrorResponseBuilder(props, "iam-service");
+        }
+
+        @Bean
+        SecurityFilterChain testSecurity(HttpSecurity http) throws Exception {
+            http.csrf(csrf -> csrf.disable())
+                    .authorizeHttpRequests(auth -> auth
+                            .requestMatchers("/iam/internal/v1/**").hasRole("ADMIN")
+                            .requestMatchers("/iam/api/v1/users/*/roles").hasRole("ADMIN")
+                            .anyRequest().denyAll());
+            return http.build();
+        }
+    }
 
     @Autowired
     private MockMvc mvc;
@@ -26,6 +58,7 @@ class UserQueryControllerTest {
     @MockBean EntitlementQueries entitlements;
 
     @Test
+    @WithMockUser(roles = "ADMIN")
     void getRoles_ok() throws Exception {
         var acc = UUID.randomUUID();
         when(queries.getUserRoleNames(acc)).thenReturn(List.of("ADMIN","USER"));
@@ -34,5 +67,26 @@ class UserQueryControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0]").value("ADMIN"))
                 .andExpect(jsonPath("$[1]").value("USER"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void getRolesPublic_ok() throws Exception {
+        var acc = UUID.randomUUID();
+        when(queries.getUserRoleNames(acc)).thenReturn(List.of("ADMIN","USER"));
+
+        mvc.perform(get("/iam/api/v1/users/" + acc + "/roles"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0]").value("ADMIN"))
+                .andExpect(jsonPath("$[1]").value("USER"));
+    }
+
+    @Test
+    @WithMockUser // default role USER
+    void getRolesPublic_forbidden() throws Exception {
+        var acc = UUID.randomUUID();
+
+        mvc.perform(get("/iam/api/v1/users/" + acc + "/roles"))
+                .andExpect(status().isForbidden());
     }
 }


### PR DESCRIPTION
## Summary
- expose public endpoint to retrieve user role names
- reuse existing query service for public role lookup
- cover new endpoint with WebMvc test
- expose authenticated user listing endpoint
- add account query service and JPA support for user lookup
- verify user listing via WebMvc test
- permit admin to access public user-role lookup and document requirement
- enforce role checks in WebMvc tests

## Testing
- `mvn -pl auth-service -am test`
- `mvn -pl iam-service -am test`


------
https://chatgpt.com/codex/tasks/task_e_68c187feb238832ea22203b6c4dc012a