### PR TITLE
fix(auth): secure user listing endpoint

### DIFF
--- a/auth-service/pom.xml
+++ b/auth-service/pom.xml
@@ -132,6 +132,11 @@
             <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/auth-service/src/main/java/com/example/auth/config/SecurityConfig.java
+++ b/auth-service/src/main/java/com/example/auth/config/SecurityConfig.java
@@ -20,7 +20,12 @@ public class SecurityConfig {
         http.csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(reg -> reg
                         // Auth endpoints (public)
-                        .requestMatchers("/auth/api/v1/**").permitAll()
+                        .requestMatchers(
+                                "/auth/api/v1/register",
+                                "/auth/api/v1/login",
+                                "/auth/api/v1/refresh",
+                                "/auth/api/v1/logout"
+                        ).permitAll()
                         .requestMatchers("/.well-known/**", "/actuator/health").permitAll()
                         .requestMatchers("/v3/api-docs/**").permitAll()
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()

--- a/auth-service/src/test/java/com/example/auth/web/GlobalErrorControllerTest.java
+++ b/auth-service/src/test/java/com/example/auth/web/GlobalErrorControllerTest.java
@@ -8,6 +8,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.security.test.context.support.WithMockUser;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -23,11 +24,12 @@ class GlobalErrorControllerTest {
     @MockBean
     EntitlementClient entitlementClient;
 
-	@Test
-	void unknownEndpoint_returns404() throws Exception {
-		mvc.perform(post("/auth/api/v1/registered")) // tidak ada handler
-				.andExpect(status().isNotFound())
-				.andExpect(jsonPath("$.code", equalTo("not_found")))
-				.andExpect(jsonPath("$.message", equalTo("Resource not found")));
-	}
+        @Test
+        @WithMockUser
+        void unknownEndpoint_returns404() throws Exception {
+                mvc.perform(post("/auth/api/v1/registered")) // tidak ada handler
+                                .andExpect(status().isNotFound())
+                                .andExpect(jsonPath("$.code", equalTo("not_found")))
+                                .andExpect(jsonPath("$.message", equalTo("Resource not found")));
+        }
 }

--- a/auth-service/src/test/java/com/example/auth/web/UserControllerTest.java
+++ b/auth-service/src/test/java/com/example/auth/web/UserControllerTest.java
@@ -2,6 +2,7 @@ package com.example.auth.web;
 
 import com.example.auth.application.account.AccountQueries;
 import com.example.auth.config.CommonWebConfig;
+import com.example.auth.config.SecurityConfig;
 import com.example.auth.domain.account.Account;
 import jakarta.annotation.Resource;
 import org.junit.jupiter.api.Test;
@@ -9,6 +10,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -22,8 +24,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(controllers = UserController.class)
-@AutoConfigureMockMvc(addFilters = false)
-@Import(CommonWebConfig.class)
+@AutoConfigureMockMvc
+@Import({CommonWebConfig.class, SecurityConfig.class})
 @ActiveProfiles("test")
 class UserControllerTest {
 
@@ -31,6 +33,13 @@ class UserControllerTest {
     @MockBean AccountQueries accountQueries;
 
     @Test
+    void listUsers_unauthenticated_returns401() throws Exception {
+        mvc.perform(get("/auth/api/v1/users"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser
     void listUsers_ok() throws Exception {
         var a1 = Account.of(UUID.randomUUID(), "alice", "a@x.io", "h", "ACTIVE", OffsetDateTime.now(ZoneOffset.UTC));
         var a2 = Account.of(UUID.randomUUID(), "bob", "b@x.io", "h", "ACTIVE", OffsetDateTime.now(ZoneOffset.UTC));


### PR DESCRIPTION
## Summary
- restrict public auth endpoints to register/login/refresh/logout
- require authentication for user listing
- cover user listing auth and adjust error test

## Testing
- `mvn -pl auth-service -am test`


------
https://chatgpt.com/codex/tasks/task_e_68c19dfc827c832e99bd475e42d8d6ab