### PR TITLE
feat(iam): add v2 search and sort for permissions and roles

### DIFF
--- a/docs/openapi/iam.yaml
+++ b/docs/openapi/iam.yaml
@@ -189,6 +189,25 @@ paths:
           name: size
           schema: { type: integer, minimum: 1, maximum: 200, default: 20 }
           description: Page size
+        - in: query
+          name: q
+          schema: { type: string, minLength: 2 }
+          description: |
+            Free-text search (case-insensitive contains). Applied to name and description.
+            Minimum length 2. Tokens separated by space are ANDed; fields are ORed.
+        - in: query
+          name: sort
+          style: form
+          explode: true
+          allowReserved: true
+          schema:
+            type: array
+            items:
+              type: string
+              description: "Sort clause in the form '<field>[,asc|desc]'. Default direction asc."
+          description: |
+            Sorting by one or more fields. Allowed fields: id, name, description.
+            Example: sort=name,asc&sort=id,asc
       responses:
         '200':
           description: OK
@@ -212,6 +231,25 @@ paths:
           name: size
           schema: { type: integer, minimum: 1, maximum: 200, default: 20 }
           description: Page size
+        - in: query
+          name: q
+          schema: { type: string, minLength: 2 }
+          description: |
+            Free-text search (case-insensitive contains). Applied to name only.
+            Minimum length 2. Tokens separated by space are ANDed.
+        - in: query
+          name: sort
+          style: form
+          explode: true
+          allowReserved: true
+          schema:
+            type: array
+            items:
+              type: string
+              description: "Sort clause in the form '<field>[,asc|desc]'. Default direction asc."
+          description: |
+            Sorting by one or more fields. Allowed fields: id, name.
+            Example: sort=name,asc&sort=id,asc
       responses:
         '200': { description: OK, content: { application/json: { schema: { $ref: '#/components/schemas/RolePage' } } } }
 

--- a/iam-service/src/main/java/com/example/iam/application/permission/PermissionQueries.java
+++ b/iam-service/src/main/java/com/example/iam/application/permission/PermissionQueries.java
@@ -3,7 +3,10 @@ package com.example.iam.application.permission;
 import com.example.iam.domain.common.PageResult;
 import com.example.iam.domain.permission.Permission;
 
+import java.util.List;
+
 public interface PermissionQueries {
     PageResult<Permission> list(int page, int size);
+    PageResult<Permission> search(String q, List<String> sort, int page, int size);
     Permission getById(Long id);
 }

--- a/iam-service/src/main/java/com/example/iam/application/permission/PermissionQueryService.java
+++ b/iam-service/src/main/java/com/example/iam/application/permission/PermissionQueryService.java
@@ -5,10 +5,13 @@ import com.example.iam.domain.permission.Permission;
 import com.example.iam.domain.permission.PermissionRepository;
 import lombok.RequiredArgsConstructor;
 
+import java.util.List;
+
 @RequiredArgsConstructor
 public class PermissionQueryService implements PermissionQueries {
     private final PermissionRepository repo;
 
     @Override public PageResult<Permission> list(int page, int size) { return repo.findAllPaged(page, size); }
+    @Override public PageResult<Permission> search(String q, List<String> sort, int page, int size) { return repo.search(q, sort, page, size); }
     @Override public Permission getById(Long id) { return repo.findById(id).orElseThrow(); }
 }

--- a/iam-service/src/main/java/com/example/iam/application/role/RoleQueries.java
+++ b/iam-service/src/main/java/com/example/iam/application/role/RoleQueries.java
@@ -4,8 +4,11 @@ import com.example.iam.domain.common.PageResult;
 import com.example.iam.domain.role.Role;
 import com.example.iam.domain.permission.Permission;
 
+import java.util.List;
+
 public interface RoleQueries {
     PageResult<Role> list(int page, int size);
+    PageResult<Role> search(String q, List<String> sort, int page, int size);
     Role getById(Long id);
     PageResult<Permission> listPermissions(Long roleId, int page, int size);
     PageResult<Permission> listAvailablePermissions(Long roleId, int page, int size);

--- a/iam-service/src/main/java/com/example/iam/application/role/RoleQueryService.java
+++ b/iam-service/src/main/java/com/example/iam/application/role/RoleQueryService.java
@@ -17,6 +17,7 @@ public class RoleQueryService implements RoleQueries {
     private final RolePermissionRepository rolePermRepo;
 
     @Override public PageResult<Role> list(int page, int size) { return roleRepo.findAllPaged(page, size); }
+    @Override public PageResult<Role> search(String q, List<String> sort, int page, int size) { return roleRepo.search(q, sort, page, size); }
     @Override public Role getById(Long id) { return roleRepo.findById(id).orElseThrow(); }
 
     @Override

--- a/iam-service/src/main/java/com/example/iam/domain/permission/PermissionRepository.java
+++ b/iam-service/src/main/java/com/example/iam/domain/permission/PermissionRepository.java
@@ -9,6 +9,7 @@ public interface PermissionRepository {
     Optional<Permission> findByName(String name);
     List<Permission> findAll();
     PageResult<Permission> findAllPaged(int page, int size);
+    PageResult<Permission> search(String q, List<String> sort, int page, int size);
     void deleteById(Long id);
     List<Permission> findAllByIds(Collection<Long> ids);
     List<String> findNamesByIds(Collection<Long> ids);

--- a/iam-service/src/main/java/com/example/iam/domain/role/RoleRepository.java
+++ b/iam-service/src/main/java/com/example/iam/domain/role/RoleRepository.java
@@ -9,5 +9,6 @@ public interface RoleRepository {
     Optional<Role> findByName(String name);
     List<Role> findAll();
     PageResult<Role> findAllPaged(int page, int size);
+    PageResult<Role> search(String q, List<String> sort, int page, int size);
     void deleteById(Long id);
 }

--- a/iam-service/src/main/java/com/example/iam/infrastructure/jpa/PermissionRepositoryImpl.java
+++ b/iam-service/src/main/java/com/example/iam/infrastructure/jpa/PermissionRepositoryImpl.java
@@ -3,11 +3,17 @@ package com.example.iam.infrastructure.jpa;
 import com.example.iam.domain.common.PageResult;
 import com.example.iam.domain.permission.Permission;
 import com.example.iam.domain.permission.PermissionRepository;
+import com.example.iam.infrastructure.jpa.entity.PermissionJpa;
 import com.example.iam.infrastructure.jpa.mapper.JpaMapper;
 import com.example.iam.infrastructure.jpa.repository.JpaPermissionRepository;
+import jakarta.persistence.criteria.Predicate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -46,6 +52,15 @@ public class PermissionRepositoryImpl implements PermissionRepository {
     }
 
     @Override
+    public PageResult<Permission> search(String q, List<String> sort, int page, int size) {
+        var spec = buildPermissionSpec(q);
+        var pageable = PageRequest.of(Math.max(0, page), Math.max(1, size), buildSort(sort));
+        var p = repo.findAll(spec, pageable);
+        var content = p.getContent().stream().map(JpaMapper::toDomain).toList();
+        return new PageResult<>(content, p.getNumber(), p.getSize(), p.getTotalElements(), p.getTotalPages());
+    }
+
+    @Override
     public void deleteById(Long id) {
         repo.deleteById(id);
     }
@@ -59,5 +74,68 @@ public class PermissionRepositoryImpl implements PermissionRepository {
     public List<String> findNamesByIds(Collection<Long> ids) {
         if (ids == null || ids.isEmpty()) return List.of();
         return repo.findNamesByIds(ids);
+    }
+
+    private static Specification<PermissionJpa> buildPermissionSpec(String q) {
+        return (root, query, cb) -> {
+            if (q == null || q.isBlank()) {
+                return cb.conjunction();
+            }
+            var tokens = Arrays.stream(q.trim().split("\\s+")).filter(s -> !s.isBlank()).toList();
+            var andPredicates = new ArrayList<Predicate>();
+            for (var t : tokens) {
+                String like = "%" + t.toLowerCase() + "%";
+                var nameLike = cb.like(cb.lower(root.get("name")), like);
+                var descLike = cb.like(cb.lower(root.get("description")), like);
+                andPredicates.add(cb.or(nameLike, descLike));
+            }
+            return andPredicates.isEmpty() ? cb.conjunction() : cb.and(andPredicates.toArray(new Predicate[0]));
+        };
+    }
+
+    private static Sort buildSort(List<String> sorts) {
+        if (sorts == null || sorts.isEmpty()) {
+            // default sort by id desc to mimic createdAt:desc notion not present in schema
+            return Sort.by(Sort.Order.desc("id"));
+        }
+        var allowed = java.util.Set.of("id", "name", "description");
+        var orders = new ArrayList<Sort.Order>();
+        for (int i = 0; i < sorts.size(); i++) {
+            String raw = sorts.get(i);
+            if (raw == null || raw.isBlank()) continue;
+
+            String field;
+            String dirStr = null;
+            if (raw.contains(",")) {
+                String[] parts = raw.split(",");
+                field = parts[0].trim();
+                if (parts.length > 1) dirStr = parts[1].trim();
+            } else {
+                field = raw.trim();
+                // Handle Spring splitting CSV into separate values: sort=name,ASC becomes ["name", "ASC"]
+                if (i + 1 < sorts.size()) {
+                    String next = sorts.get(i + 1);
+                    if (next != null) {
+                        String nd = next.trim().toLowerCase();
+                        if (nd.equals("asc") || nd.equals("desc")) {
+                            dirStr = next.trim();
+                            i++; // consume next as direction
+                        }
+                    }
+                }
+            }
+
+            if (!allowed.contains(field)) {
+                throw new IllegalArgumentException("invalid sort field: " + field);
+            }
+            Sort.Direction dir = Sort.Direction.ASC;
+            if (dirStr != null && !dirStr.isBlank()) {
+                var d = dirStr.trim().toLowerCase();
+                if (d.equals("desc")) dir = Sort.Direction.DESC;
+                else if (!d.equals("asc")) throw new IllegalArgumentException("invalid sort direction: " + dirStr);
+            }
+            orders.add(new Sort.Order(dir, field));
+        }
+        return orders.isEmpty() ? Sort.by(Sort.Order.asc("id")) : Sort.by(orders);
     }
 }

--- a/iam-service/src/main/java/com/example/iam/infrastructure/jpa/RoleRepositoryImpl.java
+++ b/iam-service/src/main/java/com/example/iam/infrastructure/jpa/RoleRepositoryImpl.java
@@ -5,9 +5,14 @@ import com.example.iam.domain.role.Role;
 import com.example.iam.domain.role.RoleRepository;
 import com.example.iam.infrastructure.jpa.mapper.JpaMapper;
 import com.example.iam.infrastructure.jpa.repository.JpaRoleRepository;
+import jakarta.persistence.criteria.Predicate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -44,7 +49,73 @@ public class RoleRepositoryImpl implements RoleRepository {
     }
 
     @Override
+    public PageResult<Role> search(String q, List<String> sort, int page, int size) {
+        var spec = buildRoleSpec(q);
+        var pageable = PageRequest.of(Math.max(0, page), Math.max(1, size), buildSort(sort));
+        var p = repo.findAll(spec, pageable);
+        var content = p.getContent().stream().map(JpaMapper::toDomain).toList();
+        return new PageResult<>(content, p.getNumber(), p.getSize(), p.getTotalElements(), p.getTotalPages());
+    }
+
+    @Override
     public void deleteById(Long id) {
         repo.deleteById(id);
+    }
+
+    private static Specification<com.example.iam.infrastructure.jpa.entity.RoleJpa> buildRoleSpec(String q) {
+        return (root, query, cb) -> {
+            if (q == null || q.isBlank()) return cb.conjunction();
+            var tokens = Arrays.stream(q.trim().split("\\s+")).filter(s -> !s.isBlank()).toList();
+            var andPreds = new java.util.ArrayList<Predicate>();
+            for (var t : tokens) {
+                String like = "%" + t.toLowerCase() + "%";
+                andPreds.add(cb.like(cb.lower(root.get("name")), like));
+            }
+            return andPreds.isEmpty() ? cb.conjunction() : cb.and(andPreds.toArray(new Predicate[0]));
+        };
+    }
+
+    private static Sort buildSort(List<String> sorts) {
+        if (sorts == null || sorts.isEmpty()) {
+            return Sort.by(Sort.Order.desc("id"));
+        }
+        var allowed = java.util.Set.of("id", "name");
+        var orders = new ArrayList<Sort.Order>();
+        for (int i = 0; i < sorts.size(); i++) {
+            String raw = sorts.get(i);
+            if (raw == null || raw.isBlank()) continue;
+
+            String field;
+            String dirStr = null;
+            if (raw.contains(",")) {
+                String[] parts = raw.split(",");
+                field = parts[0].trim();
+                if (parts.length > 1) dirStr = parts[1].trim();
+            } else {
+                field = raw.trim();
+                if (i + 1 < sorts.size()) {
+                    String next = sorts.get(i + 1);
+                    if (next != null) {
+                        String nd = next.trim().toLowerCase();
+                        if (nd.equals("asc") || nd.equals("desc")) {
+                            dirStr = next.trim();
+                            i++; // consume next token as direction
+                        }
+                    }
+                }
+            }
+
+            if (!allowed.contains(field)) {
+                throw new IllegalArgumentException("invalid sort field: " + field);
+            }
+            Sort.Direction dir = Sort.Direction.ASC;
+            if (dirStr != null && !dirStr.isBlank()) {
+                var d = dirStr.trim().toLowerCase();
+                if (d.equals("desc")) dir = Sort.Direction.DESC;
+                else if (!d.equals("asc")) throw new IllegalArgumentException("invalid sort direction: " + dirStr);
+            }
+            orders.add(new Sort.Order(dir, field));
+        }
+        return orders.isEmpty() ? Sort.by(Sort.Order.asc("id")) : Sort.by(orders);
     }
 }

--- a/iam-service/src/main/java/com/example/iam/infrastructure/jpa/repository/JpaPermissionRepository.java
+++ b/iam-service/src/main/java/com/example/iam/infrastructure/jpa/repository/JpaPermissionRepository.java
@@ -2,13 +2,14 @@ package com.example.iam.infrastructure.jpa.repository;
 
 import com.example.iam.infrastructure.jpa.entity.PermissionJpa;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
-public interface JpaPermissionRepository extends JpaRepository<PermissionJpa, Long> {
+public interface JpaPermissionRepository extends JpaRepository<PermissionJpa, Long>, JpaSpecificationExecutor<PermissionJpa> {
     Optional<PermissionJpa> findByName(String name);
 
     @Query("select p.name from PermissionJpa p where p.id in ?1")

--- a/iam-service/src/main/java/com/example/iam/infrastructure/jpa/repository/JpaRoleRepository.java
+++ b/iam-service/src/main/java/com/example/iam/infrastructure/jpa/repository/JpaRoleRepository.java
@@ -2,8 +2,9 @@ package com.example.iam.infrastructure.jpa.repository;
 
 import com.example.iam.infrastructure.jpa.entity.RoleJpa;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import java.util.Optional;
 
-public interface JpaRoleRepository extends JpaRepository<RoleJpa, Long> {
+public interface JpaRoleRepository extends JpaRepository<RoleJpa, Long>, JpaSpecificationExecutor<RoleJpa> {
     Optional<RoleJpa> findByName(String name);
 }

--- a/iam-service/src/main/java/com/example/iam/web/GlobalExceptionHandler.java
+++ b/iam-service/src/main/java/com/example/iam/web/GlobalExceptionHandler.java
@@ -42,7 +42,7 @@ public class GlobalExceptionHandler {
         return respond(req, HttpStatus.BAD_REQUEST, "bad_request:validation", "Validation failed", ex, extra);
     }
 
-    // 400 – validasi pada @RequestParam / @PathVariable
+    // 400 - validasi pada @RequestParam / @PathVariable
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<?> constraintViolation(HttpServletRequest req, ConstraintViolationException ex) {
         Map<String, Object> extra = Map.of("errors",
@@ -50,6 +50,12 @@ public class GlobalExceptionHandler {
                         .map(cv -> Map.of("property", cv.getPropertyPath().toString(), "message", cv.getMessage()))
                         .toList());
         return respond(req, HttpStatus.BAD_REQUEST, "bad_request:constraints", "Constraint violation", ex, extra);
+    }
+
+    // 400 - invalid query/sort/etc
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<?> illegalArgument(HttpServletRequest req, IllegalArgumentException ex) {
+        return respond(req, HttpStatus.BAD_REQUEST, "bad_request:invalid_argument", ex.getMessage(), ex, null);
     }
 
     // 404 – entity/record tidak ditemukan

--- a/iam-service/src/main/java/com/example/iam/web/PermissionController.java
+++ b/iam-service/src/main/java/com/example/iam/web/PermissionController.java
@@ -42,8 +42,8 @@ public class PermissionController implements PermissionApi {
     }
 
     @Override
-    public ResponseEntity<PermissionPage> listPermissionsV2(Integer page, Integer size) {
-        var pr = queries.list(page == null ? 0 : page, size == null ? 20 : size);
+    public ResponseEntity<PermissionPage> listPermissionsV2(Integer page, Integer size, String q, List<String> sort) {
+        var pr = queries.search(q, sort, page == null ? 0 : page, size == null ? 20 : size);
         var content = pr.content().stream().map(PermissionController::map).toList();
         var body = new PermissionPage()
                 .content(content)

--- a/iam-service/src/main/java/com/example/iam/web/RoleController.java
+++ b/iam-service/src/main/java/com/example/iam/web/RoleController.java
@@ -44,8 +44,8 @@ public class RoleController implements RoleApi {
     }
 
     @Override
-    public ResponseEntity<RolePage> listRolesV2(Integer page, Integer size) {
-        var pr = queries.list(page == null ? 0 : page, size == null ? 20 : size);
+    public ResponseEntity<RolePage> listRolesV2(Integer page, Integer size, String q, List<String> sort) {
+        var pr = queries.search(q, sort, page == null ? 0 : page, size == null ? 20 : size);
         var content = pr.content().stream().map(RoleController::map).toList();
         var body = new RolePage()
                 .content(content)

--- a/iam-service/src/test/java/com/example/iam/infrastructure/jpa/RoleRepositoryImplTest.java
+++ b/iam-service/src/test/java/com/example/iam/infrastructure/jpa/RoleRepositoryImplTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.Import;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Import(RoleRepositoryImpl.class)
 class RoleRepositoryImplTest extends BaseJpaSliceTest {
@@ -29,9 +30,27 @@ class RoleRepositoryImplTest extends BaseJpaSliceTest {
 	}
 
 	@Test
-	void findAll() {
-		repo.save(Role.ofNew("R1"));
-		repo.save(Role.ofNew("R2"));
-		assertThat(repo.findAll()).hasSize(2);
-	}
+    void findAll() {
+        repo.save(Role.ofNew("R1"));
+        repo.save(Role.ofNew("R2"));
+        assertThat(repo.findAll()).hasSize(2);
+    }
+
+    @Test
+    void search_q_and_sort() {
+        repo.save(Role.ofNew("ADMIN"));
+        repo.save(Role.ofNew("MANAGER"));
+        repo.save(Role.ofNew("READER"));
+
+        // FE CSV split form
+        var page = repo.search("man", java.util.List.of("name", "DESC"), 0, 10);
+        assertThat(page.content()).extracting(Role::getName).containsExactly("MANAGER");
+
+        var asc = repo.search("", java.util.List.of("name,asc"), 0, 10);
+        assertThat(asc.content()).extracting(Role::getName).contains("ADMIN", "MANAGER", "READER");
+
+        assertThatThrownBy(() -> repo.search(null, java.util.List.of("bogus,asc"), 0, 5))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("invalid sort field");
+    }
 }

--- a/iam-service/src/test/java/com/example/iam/web/RoleControllerTest.java
+++ b/iam-service/src/test/java/com/example/iam/web/RoleControllerTest.java
@@ -43,7 +43,7 @@ class RoleControllerTest {
 
     @Test
     void list_v2_ok() throws Exception {
-        when(queries.list(0, 20)).thenReturn(PageResult.of(List.of(new Role(1L,"ADMIN")), 0, 20, 1));
+        when(queries.search(null, null, 0, 20)).thenReturn(PageResult.of(List.of(new Role(1L,"ADMIN")), 0, 20, 1));
         mvc.perform(get("/iam/api/v2/roles"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content[0].name").value("ADMIN"))
@@ -51,6 +51,18 @@ class RoleControllerTest {
                 .andExpect(jsonPath("$.size").value(20))
                 .andExpect(jsonPath("$.totalElements").value(1))
                 .andExpect(jsonPath("$.totalPages").value(1));
+    }
+
+    @Test
+    void list_v2_with_q_and_sort_ok() throws Exception {
+        when(queries.search(any(), any(), anyInt(), anyInt()))
+                .thenReturn(PageResult.of(List.of(new Role(1L, "ADMIN")), 0, 5, 1));
+        mvc.perform(get("/iam/api/v2/roles")
+                        .param("q","adm")
+                        .param("size","5")
+                        .param("sort","name,asc"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].name").value("ADMIN"));
     }
 
     @Test


### PR DESCRIPTION
Implement query 'q' and 'sort' on /iam/api/v2/permissions and /iam/api/v2/roles with JPA specifications and normalized sort parsing. Controllers now delegate to application search.