### PR TITLE
Centralize catalog ownership checks

### DIFF
--- a/catalog-service/src/main/java/com/example/catalog/application/sku/SkuCommandService.java
+++ b/catalog-service/src/main/java/com/example/catalog/application/sku/SkuCommandService.java
@@ -3,10 +3,12 @@ package com.example.catalog.application.sku;
 import com.example.catalog.application.sku.events.SkuActivated;
 import com.example.catalog.application.sku.events.SkuCreated;
 import com.example.catalog.application.sku.events.SkuDeactivated;
+import com.example.catalog.domain.product.ProductRepository;
 import com.example.catalog.domain.sku.Sku;
 import com.example.catalog.domain.sku.SkuRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
@@ -16,10 +18,12 @@ import java.util.UUID;
 public class SkuCommandService implements SkuCommands {
 
     private final SkuRepository repo;
+    private final ProductRepository productRepository;
     private final ApplicationEventPublisher events;
 
     @Override
-    public Sku create(UUID productId, String skuCode, Boolean active, String barcode) {
+    public Sku create(UUID actorId, UUID productId, String skuCode, Boolean active, String barcode, boolean overrideOwnership) {
+        requireOwnership(actorId, productId, overrideOwnership);
         Sku s = Sku.builder()
                 .id(UUID.randomUUID())
                 .productId(productId)
@@ -39,8 +43,9 @@ public class SkuCommandService implements SkuCommands {
     }
 
     @Override
-    public Sku update(UUID id, String skuCode, Boolean active, String barcode) {
+    public Sku update(UUID actorId, UUID id, String skuCode, Boolean active, String barcode, boolean overrideOwnership) {
         Sku current = repo.findById(id).orElseThrow();
+        requireOwnership(actorId, current.getProductId(), overrideOwnership);
         boolean wasActive = current.isActive();
 
         current.setSkuCode(skuCode != null ? skuCode : current.getSkuCode());
@@ -60,8 +65,24 @@ public class SkuCommandService implements SkuCommands {
     }
 
     @Override
-    public void delete(UUID id) {
+    public void delete(UUID actorId, UUID id, boolean overrideOwnership) {
+        Sku current = repo.findById(id).orElseThrow();
+        requireOwnership(actorId, current.getProductId(), overrideOwnership);
         repo.deleteById(id);
+    }
+
+    private void requireOwnership(UUID actorId, UUID productId, boolean overrideOwnership) {
+        var product = productRepository.findById(productId).orElseThrow();
+        if (overrideOwnership) {
+            return;
+        }
+        if (actorId == null) {
+            throw new AccessDeniedException("Actor is required to manage SKUs");
+        }
+        UUID ownerId = product.getCreatedBy();
+        if (ownerId != null && !ownerId.equals(actorId)) {
+            throw new AccessDeniedException("Only the product owner may manage SKUs for this product");
+        }
     }
 }
 

--- a/catalog-service/src/main/java/com/example/catalog/application/sku/SkuCommands.java
+++ b/catalog-service/src/main/java/com/example/catalog/application/sku/SkuCommands.java
@@ -5,8 +5,8 @@ import com.example.catalog.domain.sku.Sku;
 import java.util.UUID;
 
 public interface SkuCommands {
-    Sku create(UUID productId, String skuCode, Boolean active, String barcode);
-    Sku update(UUID id, String skuCode, Boolean active, String barcode);
-    void delete(UUID id);
+    Sku create(UUID actorId, UUID productId, String skuCode, Boolean active, String barcode, boolean overrideOwnership);
+    Sku update(UUID actorId, UUID id, String skuCode, Boolean active, String barcode, boolean overrideOwnership);
+    void delete(UUID actorId, UUID id, boolean overrideOwnership);
 }
 

--- a/catalog-service/src/main/java/com/example/catalog/config/CatalogBeanConfig.java
+++ b/catalog-service/src/main/java/com/example/catalog/config/CatalogBeanConfig.java
@@ -70,8 +70,8 @@ public class CatalogBeanConfig {
     }
 
     @Bean
-    SkuCommands skuCommands(SkuRepository repo, ApplicationEventPublisher events) {
-        return new SkuCommandService(repo, events);
+    SkuCommands skuCommands(SkuRepository repo, ProductRepository productRepository, ApplicationEventPublisher events) {
+        return new SkuCommandService(repo, productRepository, events);
     }
 
     @Bean

--- a/catalog-service/src/main/java/com/example/catalog/security/AbstractOwnershipEvaluator.java
+++ b/catalog-service/src/main/java/com/example/catalog/security/AbstractOwnershipEvaluator.java
@@ -1,0 +1,78 @@
+package com.example.catalog.security;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Base evaluator that extracts the JWT subject as the acting user and compares it with
+ * the owner information resolved from a resource identifier.
+ */
+public abstract class AbstractOwnershipEvaluator<ID> {
+
+    /**
+     * Resolve the current authenticated actor identifier from the provided authentication.
+     *
+     * @param authentication the authentication instance, typically a JWT token
+     * @return optional containing the actor identifier if resolvable
+     */
+    public Optional<UUID> currentActorId(Authentication authentication) {
+        if (authentication instanceof JwtAuthenticationToken token) {
+            String subject = token.getToken().getSubject();
+            if (subject != null) {
+                try {
+                    return Optional.of(UUID.fromString(subject));
+                } catch (IllegalArgumentException ignored) {
+                    // fall through to empty optional
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Resolve the current authenticated actor identifier or throw if not available.
+     *
+     * @param authentication the authentication instance
+     * @return the actor identifier
+     * @throws IllegalStateException if the identifier cannot be resolved
+     */
+    public UUID requireCurrentActorId(Authentication authentication) {
+        return currentActorId(authentication)
+                .orElseThrow(() -> new IllegalStateException("Authenticated user subject is required"));
+    }
+
+    /**
+     * Determine whether the current authentication represents the owner of the resource.
+     *
+     * @param authentication the authentication
+     * @param resourceId     the resource identifier
+     * @return {@code true} if the current actor owns the resource
+     */
+    public boolean isOwner(Authentication authentication, ID resourceId) {
+        if (resourceId == null) {
+            return false;
+        }
+        Optional<UUID> actorId = currentActorId(authentication);
+        if (actorId.isEmpty()) {
+            return false;
+        }
+        try {
+            return loadOwnerId(resourceId)
+                    .map(actorId.get()::equals)
+                    .orElse(false);
+        } catch (RuntimeException ex) {
+            return false;
+        }
+    }
+
+    /**
+     * Load the owner identifier for the provided resource.
+     *
+     * @param resourceId the resource identifier
+     * @return optional owner identifier
+     */
+    protected abstract Optional<UUID> loadOwnerId(ID resourceId);
+}

--- a/catalog-service/src/main/java/com/example/catalog/security/SkuAccessEvaluator.java
+++ b/catalog-service/src/main/java/com/example/catalog/security/SkuAccessEvaluator.java
@@ -1,0 +1,31 @@
+package com.example.catalog.security;
+
+import com.example.catalog.application.product.ProductQueries;
+import com.example.catalog.domain.sku.SkuRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Component("skuAccessEvaluator")
+@RequiredArgsConstructor
+public class SkuAccessEvaluator extends AbstractOwnershipEvaluator<UUID> {
+
+    private final SkuRepository skuRepository;
+    private final ProductQueries productQueries;
+
+    @Override
+    protected Optional<UUID> loadOwnerId(UUID skuId) {
+        return skuRepository.findById(skuId)
+                .map(com.example.catalog.domain.sku.Sku::getProductId)
+                .flatMap(productId -> {
+                    try {
+                        var product = productQueries.getById(productId);
+                        return Optional.ofNullable(product.getCreatedBy());
+                    } catch (RuntimeException ex) {
+                        return Optional.empty();
+                    }
+                });
+    }
+}

--- a/catalog-service/src/test/java/com/example/catalog/application/sku/SkuCommandServiceTest.java
+++ b/catalog-service/src/test/java/com/example/catalog/application/sku/SkuCommandServiceTest.java
@@ -1,5 +1,7 @@
 package com.example.catalog.application.sku;
 
+import com.example.catalog.domain.product.Product;
+import com.example.catalog.domain.product.ProductRepository;
 import com.example.catalog.domain.sku.Sku;
 import com.example.catalog.domain.sku.SkuRepository;
 import org.springframework.context.ApplicationEventPublisher;
@@ -9,17 +11,22 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
 class SkuCommandServiceTest {
     SkuRepository repo = mock(SkuRepository.class);
+    ProductRepository productRepository = mock(ProductRepository.class);
     ApplicationEventPublisher events = mock(ApplicationEventPublisher.class);
-    SkuCommandService svc = new SkuCommandService(repo, events);
+    SkuCommandService svc = new SkuCommandService(repo, productRepository, events);
 
     @Test
     void create_setsDefaultsAndSaves() {
+        UUID actorId = UUID.randomUUID();
+        UUID productId = UUID.randomUUID();
+        when(productRepository.findById(productId)).thenReturn(Optional.of(Product.builder().id(productId).createdBy(actorId).build()));
         when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
-        Sku s = svc.create(UUID.randomUUID(), "S", null, null);
+        Sku s = svc.create(actorId, productId, "S", null, null, false);
         assertThat(s.getSkuCode()).isEqualTo("S");
         assertThat(s.isActive()).isTrue();
         verify(repo).save(any());
@@ -30,10 +37,13 @@ class SkuCommandServiceTest {
     @Test
     void update_mergesFields() {
         UUID id = UUID.randomUUID();
-        Sku current = Sku.builder().id(id).productId(UUID.randomUUID()).skuCode("S").active(true).build();
+        UUID actorId = UUID.randomUUID();
+        UUID productId = UUID.randomUUID();
+        Sku current = Sku.builder().id(id).productId(productId).skuCode("S").active(true).build();
         when(repo.findById(id)).thenReturn(Optional.of(current));
+        when(productRepository.findById(productId)).thenReturn(Optional.of(Product.builder().id(productId).createdBy(actorId).build()));
         when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
-        Sku updated = svc.update(id, "S2", false, "b");
+        Sku updated = svc.update(actorId, id, "S2", false, "b", false);
         assertThat(updated.getSkuCode()).isEqualTo("S2");
         assertThat(updated.isActive()).isFalse();
         assertThat(updated.getBarcode()).isEqualTo("b");
@@ -42,7 +52,22 @@ class SkuCommandServiceTest {
     @Test
     void delete_delegates() {
         UUID id = UUID.randomUUID();
-        svc.delete(id);
+        UUID actorId = UUID.randomUUID();
+        UUID productId = UUID.randomUUID();
+        when(repo.findById(id)).thenReturn(Optional.of(Sku.builder().id(id).productId(productId).build()));
+        when(productRepository.findById(productId)).thenReturn(Optional.of(Product.builder().id(productId).createdBy(actorId).build()));
+        svc.delete(actorId, id, false);
         verify(repo).deleteById(id);
+    }
+
+    @Test
+    void create_rejectsWhenActorNotOwner() {
+        UUID productId = UUID.randomUUID();
+        UUID ownerId = UUID.randomUUID();
+        UUID other = UUID.randomUUID();
+        when(productRepository.findById(productId)).thenReturn(Optional.of(Product.builder().id(productId).createdBy(ownerId).build()));
+
+        assertThatThrownBy(() -> svc.create(other, productId, "S", true, null, false))
+                .isInstanceOf(org.springframework.security.access.AccessDeniedException.class);
     }
 }

--- a/catalog-service/src/test/java/com/example/catalog/security/SkuAccessEvaluatorTest.java
+++ b/catalog-service/src/test/java/com/example/catalog/security/SkuAccessEvaluatorTest.java
@@ -1,0 +1,70 @@
+package com.example.catalog.security;
+
+import com.example.catalog.application.product.ProductQueries;
+import com.example.catalog.domain.product.Product;
+import com.example.catalog.domain.sku.Sku;
+import com.example.catalog.domain.sku.SkuRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class SkuAccessEvaluatorTest {
+
+    SkuRepository skuRepository = mock(SkuRepository.class);
+    ProductQueries productQueries = mock(ProductQueries.class);
+    SkuAccessEvaluator evaluator = new SkuAccessEvaluator(skuRepository, productQueries);
+
+    @Test
+    void isOwner_returnsTrueWhenSkuBelongsToActorProduct() {
+        UUID skuId = UUID.randomUUID();
+        UUID productId = UUID.randomUUID();
+        UUID ownerId = UUID.randomUUID();
+        when(skuRepository.findById(skuId)).thenReturn(Optional.of(Sku.builder().id(skuId).productId(productId).build()));
+        when(productQueries.getById(productId)).thenReturn(Product.builder().id(productId).createdBy(ownerId).createdAt(Instant.now()).build());
+
+        Authentication auth = jwt(ownerId);
+
+        assertThat(evaluator.isOwner(auth, skuId)).isTrue();
+    }
+
+    @Test
+    void isOwner_returnsFalseWhenProductLookupFails() {
+        UUID skuId = UUID.randomUUID();
+        UUID productId = UUID.randomUUID();
+        when(skuRepository.findById(skuId)).thenReturn(Optional.of(Sku.builder().id(skuId).productId(productId).build()));
+        when(productQueries.getById(productId)).thenThrow(new RuntimeException("not found"));
+
+        Authentication auth = jwt(UUID.randomUUID());
+
+        assertThat(evaluator.isOwner(auth, skuId)).isFalse();
+    }
+
+    @Test
+    void isOwner_returnsFalseWhenSkuMissing() {
+        UUID skuId = UUID.randomUUID();
+        when(skuRepository.findById(skuId)).thenReturn(Optional.empty());
+
+        Authentication auth = jwt(UUID.randomUUID());
+
+        assertThat(evaluator.isOwner(auth, skuId)).isFalse();
+    }
+
+    private static Authentication jwt(UUID subject) {
+        Jwt jwt = Jwt.withTokenValue("token")
+                .header("alg", "none")
+                .subject(subject.toString())
+                .claim("sub", subject.toString())
+                .issuedAt(Instant.now())
+                .expiresAt(Instant.now().plusSeconds(3600))
+                .build();
+        return new JwtAuthenticationToken(jwt);
+    }
+}

--- a/catalog-service/src/test/java/com/example/catalog/web/product/ProductControllerTest.java
+++ b/catalog-service/src/test/java/com/example/catalog/web/product/ProductControllerTest.java
@@ -4,6 +4,7 @@ import com.example.catalog.application.product.ProductCommands;
 import com.example.catalog.application.product.ProductQueries;
 import com.example.catalog.domain.common.PageResult;
 import com.example.catalog.domain.product.Product;
+import com.example.catalog.security.ProductAccessEvaluator;
 import com.example.catalog.web.GlobalExceptionHandler;
 import com.example.catalog.web.dto.ProductCreateRequest;
 import com.example.catalog.web.dto.ProductUpdateRequest;
@@ -50,7 +51,8 @@ class ProductControllerTest {
         props.setVerbose(false);
         ErrorResponseBuilder errorBuilder = new ErrorResponseBuilder(props, "catalog-service");
         GlobalExceptionHandler handler = new GlobalExceptionHandler(errorBuilder);
-        ProductController controller = new ProductController(productQueries, productCommands);
+        ProductAccessEvaluator productAccessEvaluator = new ProductAccessEvaluator(productQueries);
+        ProductController controller = new ProductController(productQueries, productCommands, productAccessEvaluator);
         mvc = MockMvcBuilders.standaloneSetup(controller)
                 .setControllerAdvice(handler)
                 .build();

--- a/catalog-service/src/test/java/com/example/catalog/web/sku/SkuControllerTest.java
+++ b/catalog-service/src/test/java/com/example/catalog/web/sku/SkuControllerTest.java
@@ -2,6 +2,8 @@ package com.example.catalog.web.sku;
 
 import com.example.catalog.application.sku.SkuCommands;
 import com.example.catalog.domain.sku.Sku;
+import com.example.catalog.security.ProductAccessEvaluator;
+import com.example.catalog.security.SkuAccessEvaluator;
 import com.example.catalog.web.dto.SkuCreateRequest;
 import com.example.catalog.web.dto.SkuUpdateRequest;
 import com.example.catalog.web.GlobalExceptionHandler;
@@ -28,16 +30,20 @@ class SkuControllerTest {
 
     @Autowired MockMvc mvc;
     @MockBean SkuCommands skuCommands;
+    @MockBean ProductAccessEvaluator productAccessEvaluator;
+    @MockBean SkuAccessEvaluator skuAccessEvaluator;
 
     @Test
     void create_ok() throws Exception {
         UUID pid = UUID.randomUUID();
+        UUID actorId = UUID.randomUUID();
         var s = Sku.builder().id(UUID.randomUUID()).productId(pid).skuCode("S").active(true).build();
-        when(skuCommands.create(eq(pid), any(), any(), any())).thenReturn(s);
+        when(productAccessEvaluator.requireCurrentActorId(any())).thenReturn(actorId);
+        when(skuCommands.create(eq(actorId), eq(pid), any(), any(), any(), eq(true))).thenReturn(s);
         var om = new com.fasterxml.jackson.databind.ObjectMapper();
         mvc.perform(post("/catalog/api/v1/products/" + pid + "/skus")
                 .contentType(MediaType.APPLICATION_JSON)
-                .with(jwt().authorities(new SimpleGrantedAuthority("catalog:sku:write")))
+                .with(jwt().authorities(new SimpleGrantedAuthority("catalog:sku:write")).jwt(jwt -> jwt.subject(actorId.toString())))
                 .content(om.writeValueAsBytes(new SkuCreateRequest(pid, "S", true, null))))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.skuCode").value("S"));
@@ -46,12 +52,14 @@ class SkuControllerTest {
     @Test
     void update_ok() throws Exception {
         UUID id = UUID.randomUUID();
+        UUID actorId = UUID.randomUUID();
         var s = Sku.builder().id(id).productId(UUID.randomUUID()).skuCode("SS").active(true).build();
-        when(skuCommands.update(eq(id), any(), any(), any())).thenReturn(s);
+        when(productAccessEvaluator.requireCurrentActorId(any())).thenReturn(actorId);
+        when(skuCommands.update(eq(actorId), eq(id), any(), any(), any(), eq(true))).thenReturn(s);
         var om = new com.fasterxml.jackson.databind.ObjectMapper();
         mvc.perform(put("/catalog/api/v1/skus/" + id)
                 .contentType(MediaType.APPLICATION_JSON)
-                .with(jwt().authorities(new SimpleGrantedAuthority("catalog:sku:write")))
+                .with(jwt().authorities(new SimpleGrantedAuthority("catalog:sku:write")).jwt(jwt -> jwt.subject(actorId.toString())))
                 .content(om.writeValueAsBytes(new SkuUpdateRequest("SS", true, null))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.skuCode").value("SS"));
@@ -60,9 +68,11 @@ class SkuControllerTest {
     @Test
     void delete_ok() throws Exception {
         UUID id = UUID.randomUUID();
+        UUID actorId = UUID.randomUUID();
+        when(productAccessEvaluator.requireCurrentActorId(any())).thenReturn(actorId);
         mvc.perform(delete("/catalog/api/v1/skus/" + id)
-                        .with(jwt().authorities(new SimpleGrantedAuthority("catalog:sku:write"))))
+                        .with(jwt().authorities(new SimpleGrantedAuthority("catalog:sku:write")).jwt(jwt -> jwt.subject(actorId.toString()))))
                 .andExpect(status().isNoContent());
-        verify(skuCommands).delete(id);
+        verify(skuCommands).delete(actorId, id, true);
     }
 }


### PR DESCRIPTION
## Summary
- introduce a reusable AbstractOwnershipEvaluator to parse JWT subjects and match resource owners
- refactor product and SKU access evaluators/controllers to reuse the helper and guard SKU endpoints
- enforce SKU ownership inside command services and expand unit tests for the new security paths

## Testing
- mvn -pl catalog-service test

------
https://chatgpt.com/codex/tasks/task_e_68cfd7fd8070832e83fe0bf696ff63e7