### PR TITLE
feat: unify role permission listing endpoints

### DIFF
--- a/auth-service/src/test/java/com/example/auth/application/account/AccountQueryServiceTest.java
+++ b/auth-service/src/test/java/com/example/auth/application/account/AccountQueryServiceTest.java
@@ -1,0 +1,58 @@
+package com.example.auth.application.account;
+
+import com.example.auth.domain.account.Account;
+import com.example.auth.domain.account.AccountRepository;
+import com.example.auth.domain.common.PageResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AccountQueryServiceTest {
+
+    @Mock
+    AccountRepository accountRepository;
+
+    @InjectMocks
+    AccountQueryService service;
+
+    PageResult<Account> samplePage;
+
+    @BeforeEach
+    void setUp() {
+        samplePage = new PageResult<>(List.<Account>of(), 0, 1, 0, 1);
+    }
+
+    @Test
+    void search_sanitizesInputsBeforeDelegating() {
+        when(accountRepository.search(eq("Alice"), eq(List.of("username ,desc", "id")), eq(0), eq(100)))
+                .thenReturn(samplePage);
+
+        var result = service.search("  Alice  ", Arrays.asList(" username ,desc ", null, " id "), -5, 500);
+
+        assertThat(result).isSameAs(samplePage);
+        verify(accountRepository).search(eq("Alice"), eq(List.of("username ,desc", "id")), eq(0), eq(100));
+    }
+
+    @Test
+    void search_allowsEmptyParameters() {
+        when(accountRepository.search(eq(null), eq(List.of()), eq(2), eq(10)))
+                .thenReturn(samplePage);
+
+        var result = service.search("   ", null, 2, 10);
+
+        assertThat(result).isSameAs(samplePage);
+        verify(accountRepository).search(eq(null), eq(List.of()), eq(2), eq(10));
+    }
+}

--- a/auth-service/src/test/java/com/example/auth/infrastructure/jpa/AccountRepositoryImplTest.java
+++ b/auth-service/src/test/java/com/example/auth/infrastructure/jpa/AccountRepositoryImplTest.java
@@ -8,9 +8,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DataJpaTest
 class AccountRepositoryImplTest {
@@ -53,5 +55,69 @@ class AccountRepositoryImplTest {
         assertThat(adapter.findByUsernameOrEmail("BOB")).isPresent();              // username ignore-case
         assertThat(adapter.findByUsernameOrEmail("B@EXAMPLE.COM")).isPresent();    // email ignore-case
         assertThat(adapter.findByUsernameOrEmail("nope")).isEmpty();
+    }
+
+    @Test
+    void search_filtersByUsername() {
+        persistAccount(UUID.fromString("00000000-0000-0000-0000-000000000001"), "alice");
+        persistAccount(UUID.fromString("00000000-0000-0000-0000-000000000002"), "bob");
+
+        var result = adapter.search("Al", List.of("username"), 0, 10);
+
+        assertThat(result.content()).extracting(Account::getUsername).containsExactly("alice");
+    }
+
+    @Test
+    void search_sanitizesPaginationAndDefaultsSort() {
+        persistAccount(UUID.fromString("00000000-0000-0000-0000-000000000003"), "alice");
+        persistAccount(UUID.fromString("00000000-0000-0000-0000-000000000004"), "charlie");
+
+        var result = adapter.search(null, null, -5, 0);
+
+        assertThat(result.page()).isZero();
+        assertThat(result.size()).isEqualTo(1);
+        assertThat(result.totalElements()).isEqualTo(2);
+        assertThat(result.totalPages()).isEqualTo(2);
+        assertThat(result.content()).extracting(Account::getUsername).containsExactly("alice");
+    }
+
+    @Test
+    void search_supportsInlineDirectionSort() {
+        var first = persistAccount(UUID.fromString("00000000-0000-0000-0000-000000000010"), "alice");
+        var second = persistAccount(UUID.fromString("00000000-0000-0000-0000-000000000020"), "bob");
+
+        var result = adapter.search(null, List.of("id,desc"), 0, 10);
+
+        assertThat(result.content()).extracting(Account::getId).containsExactly(second.getId(), first.getId());
+    }
+
+    @Test
+    void search_supportsDirectionTokenAndSkipsBlankEntries() {
+        persistAccount(UUID.fromString("00000000-0000-0000-0000-000000000100"), "alice");
+        persistAccount(UUID.fromString("00000000-0000-0000-0000-000000000200"), "bob");
+        persistAccount(UUID.fromString("00000000-0000-0000-0000-000000000300"), "charlie");
+
+        var result = adapter.search(null, List.of(" ", "username", "DESC"), 0, 10);
+
+        assertThat(result.content()).extracting(Account::getUsername).containsExactly("charlie", "bob", "alice");
+    }
+
+    @Test
+    void search_rejectsUnknownSortField() {
+        assertThatThrownBy(() -> adapter.search(null, List.of("email"), 0, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("invalid sort field");
+    }
+
+    @Test
+    void search_rejectsUnknownSortDirection() {
+        assertThatThrownBy(() -> adapter.search(null, List.of("id,down"), 0, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("invalid sort direction");
+    }
+
+    private Account persistAccount(UUID id, String username) {
+        Account account = Account.of(id, username, username + "@example.com", "HASH", "ACTIVE", OffsetDateTime.now());
+        return adapter.save(account);
     }
 }

--- a/auth-service/src/test/java/com/example/auth/web/UserControllerSortNormalizationTest.java
+++ b/auth-service/src/test/java/com/example/auth/web/UserControllerSortNormalizationTest.java
@@ -1,0 +1,59 @@
+package com.example.auth.web;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserControllerSortNormalizationTest {
+
+    @SuppressWarnings("unchecked")
+    private List<String> normalize(Object... values) {
+        return (List<String>) ReflectionTestUtils.invokeMethod(UserController.class, "normalizeSortPairs", Arrays.asList(values));
+    }
+
+    @Test
+    void normalize_ignoresNullAndBlankTokens() {
+        var normalized = normalize(null, "   ", "username", "  ");
+
+        assertThat(normalized).containsExactly("username");
+    }
+
+    @Test
+    void normalize_mergesFieldAndDirectionTokens() {
+        var normalized = normalize("username", "DESC");
+
+        assertThat(normalized).containsExactly("username,DESC");
+    }
+
+    @Test
+    void normalize_respectsCommaSeparatedValues() {
+        var normalized = normalize("id,asc", "username", "desc");
+
+        assertThat(normalized).containsExactly("id,asc", "username,desc");
+    }
+
+    @Test
+    void normalize_fieldWithNonDirectionNextValueKeepsBoth() {
+        var normalized = normalize("id", "downwards");
+
+        assertThat(normalized).containsExactly("id", "downwards");
+    }
+
+    @Test
+    void normalize_unknownFieldLeavesTokensAsIs() {
+        var normalized = normalize("email", "desc");
+
+        assertThat(normalized).containsExactly("email", "desc");
+    }
+
+    @Test
+    void normalize_fieldWithDirectionContainingCommaTreatsSeparately() {
+        var normalized = normalize("username", "desc,extra", "asc");
+
+        assertThat(normalized).containsExactly("username", "desc,extra", "asc");
+    }
+}

--- a/docs/openapi/iam.yaml
+++ b/docs/openapi/iam.yaml
@@ -143,29 +143,15 @@ paths:
         name: roleId
         required: true
         schema: { type: integer, format: int64 }
+      - in: query
+        name: available
+        required: false
+        schema: { type: boolean, default: false }
+        description: Toggle the response between permissions already assigned to the role ("false", default) and permissions still available to be assigned ("true").
     get:
       tags: [Role]
       operationId: listRolePermissions
-      summary: List permissions assigned to role
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items: { $ref: '#/components/schemas/Permission' }
-
-  /iam/api/v1/roles/{roleId}/permissions/available:
-    parameters:
-      - in: path
-        name: roleId
-        required: true
-        schema: { type: integer, format: int64 }
-    get:
-      tags: [Role]
-      operationId: listAvailableRolePermissions
-      summary: List permissions not yet assigned to role
+      summary: List permissions for role (assigned or available)
       responses:
         '200':
           description: OK
@@ -279,38 +265,15 @@ paths:
         name: roleId
         required: true
         schema: { type: integer, format: int64 }
+      - in: query
+        name: available
+        required: false
+        schema: { type: boolean, default: false }
+        description: Toggle the response between permissions already assigned to the role ("false", default) and permissions still available to be assigned ("true").
     get:
       tags: [Role]
       operationId: listRolePermissionsV2
-      summary: List permissions assigned to role (paginated)
-      security: [ { bearerAuth: [] } ]
-      parameters:
-        - in: query
-          name: page
-          schema: { type: integer, minimum: 0, default: 0 }
-          description: Zero-based page index
-        - in: query
-          name: size
-          schema: { type: integer, minimum: 1, maximum: 200, default: 20 }
-          description: Page size
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PermissionPage'
-
-  /iam/api/v2/roles/{roleId}/permissions/available:
-    parameters:
-      - in: path
-        name: roleId
-        required: true
-        schema: { type: integer, format: int64 }
-    get:
-      tags: [Role]
-      operationId: listAvailableRolePermissionsV2
-      summary: List permissions not yet assigned to role (paginated)
+      summary: List permissions for role (assigned or available, paginated)
       security: [ { bearerAuth: [] } ]
       parameters:
         - in: query

--- a/iam-service/src/main/java/com/example/iam/application/role/RoleQueries.java
+++ b/iam-service/src/main/java/com/example/iam/application/role/RoleQueries.java
@@ -10,6 +10,5 @@ public interface RoleQueries {
     PageResult<Role> list(int page, int size);
     PageResult<Role> search(String q, List<String> sort, int page, int size);
     Role getById(Long id);
-    PageResult<Permission> listPermissions(Long roleId, int page, int size);
-    PageResult<Permission> listAvailablePermissions(Long roleId, int page, int size);
+    PageResult<Permission> listPermissions(Long roleId, Boolean available, int page, int size);
 }

--- a/iam-service/src/main/java/com/example/iam/web/RoleController.java
+++ b/iam-service/src/main/java/com/example/iam/web/RoleController.java
@@ -63,33 +63,14 @@ public class RoleController implements RoleApi {
     }
 
     @Override
-    public ResponseEntity<java.util.List<com.example.iam_service.web.model.Permission>> listRolePermissions(Long roleId) {
-        var pr = queries.listPermissions(roleId, 0, Integer.MAX_VALUE);
+    public ResponseEntity<java.util.List<com.example.iam_service.web.model.Permission>> listRolePermissions(Long roleId, Boolean available) {
+        var pr = queries.listPermissions(roleId, available, 0, Integer.MAX_VALUE);
         return ResponseEntity.ok(pr.content().stream().map(RoleController::map).toList());
     }
 
     @Override
-    public ResponseEntity<PermissionPage> listRolePermissionsV2(Long roleId, Integer page, Integer size) {
-        var pr = queries.listPermissions(roleId, page == null ? 0 : page, size == null ? 20 : size);
-        var content = pr.content().stream().map(RoleController::map).toList();
-        var body = new PermissionPage()
-                .content(content)
-                .number(pr.page())
-                .size(pr.size())
-                .totalElements((int) Math.min(Integer.MAX_VALUE, Math.max(0, pr.totalElements())))
-                .totalPages(pr.totalPages());
-        return ResponseEntity.ok(body);
-    }
-
-    @Override
-    public ResponseEntity<java.util.List<com.example.iam_service.web.model.Permission>> listAvailableRolePermissions(Long roleId) {
-        var pr = queries.listAvailablePermissions(roleId, 0, Integer.MAX_VALUE);
-        return ResponseEntity.ok(pr.content().stream().map(RoleController::map).toList());
-    }
-
-    @Override
-    public ResponseEntity<PermissionPage> listAvailableRolePermissionsV2(Long roleId, Integer page, Integer size) {
-        var pr = queries.listAvailablePermissions(roleId, page == null ? 0 : page, size == null ? 20 : size);
+    public ResponseEntity<PermissionPage> listRolePermissionsV2(Long roleId, Boolean available, Integer page, Integer size) {
+        var pr = queries.listPermissions(roleId, available, page == null ? 0 : page, size == null ? 20 : size);
         var content = pr.content().stream().map(RoleController::map).toList();
         var body = new PermissionPage()
                 .content(content)

--- a/iam-service/src/test/java/com/example/iam/application/role/RoleQueryServiceTest.java
+++ b/iam-service/src/test/java/com/example/iam/application/role/RoleQueryServiceTest.java
@@ -45,16 +45,25 @@ class RoleQueryServiceTest {
     void listPermissions_ok() {
         when(rolePermRepo.findPermissionIdsByRoleId(1L)).thenReturn(List.of(1L));
         when(permRepo.findAllByIds(List.of(1L))).thenReturn(List.of(new Permission(1L, "READ", null)));
-        assertThat(svc.listPermissions(1L,0,20).content()).extracting(Permission::getName).containsExactly("READ");
+        assertThat(svc.listPermissions(1L,false,0,20).content()).extracting(Permission::getName).containsExactly("READ");
     }
 
     @Test
-    void listAvailablePermissions_ok() {
+    void listPermissions_availableTrue_ok() {
         when(rolePermRepo.findPermissionIdsByRoleId(1L)).thenReturn(List.of(1L));
         when(permRepo.findAll()).thenReturn(List.of(
                 new Permission(1L, "READ", null),
                 new Permission(2L, "WRITE", null)
         ));
-        assertThat(svc.listAvailablePermissions(1L,0,20).content()).extracting(Permission::getName).containsExactly("WRITE");
+        assertThat(svc.listPermissions(1L,true,0,20).content()).extracting(Permission::getName).containsExactly("WRITE");
+    }
+
+    @Test
+    void listPermissions_availableNull_returnsAll() {
+        when(permRepo.findAll()).thenReturn(List.of(
+                new Permission(1L, "READ", null),
+                new Permission(2L, "WRITE", null)
+        ));
+        assertThat(svc.listPermissions(1L,null,0,20).content()).extracting(Permission::getName).containsExactly("READ","WRITE");
     }
 }

--- a/iam-service/src/test/java/com/example/iam/web/RoleControllerTest.java
+++ b/iam-service/src/test/java/com/example/iam/web/RoleControllerTest.java
@@ -119,7 +119,7 @@ class RoleControllerTest {
 
     @Test
     void list_permissions_v1_ok() throws Exception {
-        when(queries.listPermissions(1L, 0, Integer.MAX_VALUE)).thenReturn(PageResult.of(List.of(new Permission(1L, "READ", null)), 0, Integer.MAX_VALUE, 1));
+        when(queries.listPermissions(1L, false, 0, Integer.MAX_VALUE)).thenReturn(PageResult.of(List.of(new Permission(1L, "READ", null)), 0, Integer.MAX_VALUE, 1));
         mvc.perform(get("/iam/api/v1/roles/1/permissions"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].name").value("READ"));
@@ -127,24 +127,24 @@ class RoleControllerTest {
 
     @Test
     void list_permissions_v2_ok() throws Exception {
-        when(queries.listPermissions(1L, 0, 20)).thenReturn(PageResult.of(List.of(new Permission(1L, "READ", null)), 0, 20, 1));
+        when(queries.listPermissions(1L, false, 0, 20)).thenReturn(PageResult.of(List.of(new Permission(1L, "READ", null)), 0, 20, 1));
         mvc.perform(get("/iam/api/v2/roles/1/permissions"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content[0].name").value("READ"));
     }
 
     @Test
-    void list_available_permissions_v1_ok() throws Exception {
-        when(queries.listAvailablePermissions(1L, 0, Integer.MAX_VALUE)).thenReturn(PageResult.of(List.of(new Permission(2L, "WRITE", null)), 0, Integer.MAX_VALUE, 1));
-        mvc.perform(get("/iam/api/v1/roles/1/permissions/available"))
+    void list_permissions_available_true_v1_ok() throws Exception {
+        when(queries.listPermissions(1L, true, 0, Integer.MAX_VALUE)).thenReturn(PageResult.of(List.of(new Permission(2L, "WRITE", null)), 0, Integer.MAX_VALUE, 1));
+        mvc.perform(get("/iam/api/v1/roles/1/permissions").param("available", "true"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].name").value("WRITE"));
     }
 
     @Test
-    void list_available_permissions_v2_ok() throws Exception {
-        when(queries.listAvailablePermissions(1L, 0, 20)).thenReturn(PageResult.of(List.of(new Permission(2L, "WRITE", null)), 0, 20, 1));
-        mvc.perform(get("/iam/api/v2/roles/1/permissions/available"))
+    void list_permissions_available_true_v2_ok() throws Exception {
+        when(queries.listPermissions(1L, true, 0, 20)).thenReturn(PageResult.of(List.of(new Permission(2L, "WRITE", null)), 0, 20, 1));
+        mvc.perform(get("/iam/api/v2/roles/1/permissions").param("available", "true"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content[0].name").value("WRITE"));
     }


### PR DESCRIPTION
## Summary
- merge IAM role permission endpoints under a single contract with an `available` toggle
- update the role query service and controller to honour the toggle and support fetching all permissions
- refresh unit tests to cover the new behaviour

## Testing
- mvn -Pcoverage test

------
https://chatgpt.com/codex/tasks/task_e_68d026853fa8832e8d179edab3f35c80