### PR TITLE
test(profile): improve coverage for profile-service

### DIFF
--- a/profile-service/src/test/java/com/example/profile/application/profile/ProfileCommandServiceTest.java
+++ b/profile-service/src/test/java/com/example/profile/application/profile/ProfileCommandServiceTest.java
@@ -1,0 +1,236 @@
+package com.example.profile.application.profile;
+
+import com.example.common.web.error.ApiException;
+import com.example.profile.application.profile.ProfileCommands.AvatarUploadCommand;
+import com.example.profile.application.profile.ProfileCommands.CreateInitialProfileCommand;
+import com.example.profile.application.profile.ProfileCommands.CreateStoreCommand;
+import com.example.profile.application.profile.ProfileCommands.UpdateProfileCommand;
+import com.example.profile.application.profile.ProfileCommands.UpdateStoreCommand;
+import com.example.profile.domain.avatar.AvatarStorageService;
+import com.example.profile.domain.common.PresignedUrl;
+import com.example.profile.domain.profile.SellerRoleGateway;
+import com.example.profile.domain.profile.UserProfile;
+import com.example.profile.domain.profile.UserProfileRepository;
+import com.example.profile.domain.store.StoreProfile;
+import com.example.profile.domain.store.StoreProfileRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class ProfileCommandServiceTest {
+
+    private UserProfileRepository userProfiles;
+    private StoreProfileRepository storeProfiles;
+    private AvatarStorageService avatarStorageService;
+    private SellerRoleGateway sellerRoleGateway;
+    private ProfileCommands service;
+
+    @BeforeEach
+    void setUp() {
+        userProfiles = mock(UserProfileRepository.class);
+        storeProfiles = mock(StoreProfileRepository.class);
+        avatarStorageService = mock(AvatarStorageService.class);
+        sellerRoleGateway = mock(SellerRoleGateway.class);
+        service = new ProfileCommandService(userProfiles, storeProfiles, avatarStorageService, sellerRoleGateway);
+    }
+
+    @Test
+    void upsertProfile_createsNewProfileWhenAbsent() {
+        UUID userId = UUID.randomUUID();
+        UpdateProfileCommand command = new UpdateProfileCommand("Alice", "Bio", "123", "avatar-key");
+        when(userProfiles.findByUserId(userId)).thenReturn(Optional.empty());
+        when(userProfiles.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        UserProfile result = service.upsertProfile(userId, command);
+
+        assertThat(result.getFullName()).isEqualTo("Alice");
+        assertThat(result.getBio()).isEqualTo("Bio");
+        assertThat(result.getPhone()).isEqualTo("123");
+        assertThat(result.getAvatarObjectKey()).isEqualTo("avatar-key");
+        assertThat(result.getCreatedAt()).isNotNull();
+        assertThat(result.getUpdatedAt()).isNotNull();
+        verify(avatarStorageService, never()).delete(anyString());
+    }
+
+    @Test
+    void upsertProfile_updatesExistingAndDeletesPreviousAvatarWhenChanged() {
+        UUID userId = UUID.randomUUID();
+        Instant created = Instant.parse("2024-01-01T00:00:00Z");
+        UserProfile existing = UserProfile.builder()
+                .userId(userId)
+                .fullName("Old")
+                .bio("Old bio")
+                .phone("000")
+                .avatarObjectKey("old-avatar")
+                .createdAt(created)
+                .updatedAt(created)
+                .build();
+        when(userProfiles.findByUserId(userId)).thenReturn(Optional.of(existing));
+        when(userProfiles.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        UpdateProfileCommand command = new UpdateProfileCommand("New", "New bio", "999", "new-avatar");
+        UserProfile result = service.upsertProfile(userId, command);
+
+        assertThat(result.getFullName()).isEqualTo("New");
+        assertThat(result.getBio()).isEqualTo("New bio");
+        assertThat(result.getPhone()).isEqualTo("999");
+        assertThat(result.getAvatarObjectKey()).isEqualTo("new-avatar");
+        assertThat(result.getCreatedAt()).isEqualTo(created);
+        assertThat(result.getUpdatedAt()).isNotNull().isAfterOrEqualTo(created);
+        verify(avatarStorageService).delete("old-avatar");
+    }
+
+    @Test
+    void upsertProfile_sameAvatar_skipsDeletion() {
+        UUID userId = UUID.randomUUID();
+        UserProfile existing = UserProfile.builder()
+                .userId(userId)
+                .avatarObjectKey("avatar")
+                .createdAt(Instant.now().minusSeconds(60))
+                .updatedAt(Instant.now().minusSeconds(60))
+                .build();
+        when(userProfiles.findByUserId(userId)).thenReturn(Optional.of(existing));
+        when(userProfiles.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        UpdateProfileCommand command = new UpdateProfileCommand("Alice", null, null, "avatar");
+        service.upsertProfile(userId, command);
+
+        verify(avatarStorageService, never()).delete(anyString());
+    }
+
+    @Test
+    void createInitialProfile_returnsExistingWithoutSaving() {
+        UUID userId = UUID.randomUUID();
+        UserProfile existing = UserProfile.builder().userId(userId).fullName("Existing").build();
+        when(userProfiles.findByUserId(userId)).thenReturn(Optional.of(existing));
+
+        UserProfile result = service.createInitialProfile(userId, new CreateInitialProfileCommand("Alice", "123"));
+
+        assertThat(result).isSameAs(existing);
+        verify(userProfiles, never()).save(any());
+    }
+
+    @Test
+    void createInitialProfile_createsProfileWhenMissing() {
+        UUID userId = UUID.randomUUID();
+        when(userProfiles.findByUserId(userId)).thenReturn(Optional.empty());
+        when(userProfiles.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        UserProfile result = service.createInitialProfile(userId, new CreateInitialProfileCommand("Alice", "123"));
+
+        assertThat(result.getUserId()).isEqualTo(userId);
+        assertThat(result.getFullName()).isEqualTo("Alice");
+        assertThat(result.getPhone()).isEqualTo("123");
+        assertThat(result.getCreatedAt()).isNotNull();
+    }
+
+    @Test
+    void prepareAvatarUpload_delegatesToStorage() {
+        UUID userId = UUID.randomUUID();
+        PresignedUrl url = PresignedUrl.builder().url("https://upload").build();
+        when(avatarStorageService.prepareUpload(eq(userId), anyString(), anyString())).thenReturn(url);
+
+        PresignedUrl result = service.prepareAvatarUpload(userId, new AvatarUploadCommand("avatar.png", "image/png"));
+
+        assertThat(result).isSameAs(url);
+    }
+
+    @Test
+    void createStore_assignsSellerRoleWhenFirstStore() {
+        UUID ownerId = UUID.randomUUID();
+        when(storeProfiles.existsByOwnerId(ownerId)).thenReturn(false);
+        when(storeProfiles.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        StoreProfile result = service.createStore(ownerId, new CreateStoreCommand("Shop", "shop", "desc"));
+
+        assertThat(result.getOwnerId()).isEqualTo(ownerId);
+        assertThat(result.getName()).isEqualTo("Shop");
+        assertThat(result.getSlug()).isEqualTo("shop");
+        assertThat(result.getDescription()).isEqualTo("desc");
+        assertThat(result.isActive()).isTrue();
+        assertThat(result.getId()).isNotNull();
+        verify(sellerRoleGateway).ensureSellerRole(ownerId);
+    }
+
+    @Test
+    void createStore_existingStoreSkipsRoleAssignment() {
+        UUID ownerId = UUID.randomUUID();
+        when(storeProfiles.existsByOwnerId(ownerId)).thenReturn(true);
+        when(storeProfiles.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        service.createStore(ownerId, new CreateStoreCommand("Shop", "shop", null));
+
+        verifyNoInteractions(sellerRoleGateway);
+    }
+
+    @Test
+    void createStore_gatewayThrowsApiException_propagates() {
+        UUID ownerId = UUID.randomUUID();
+        when(storeProfiles.existsByOwnerId(ownerId)).thenReturn(false);
+        when(storeProfiles.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        ApiException upstream = ApiException.conflict("role_conflict", "role conflict");
+        doThrow(upstream).when(sellerRoleGateway).ensureSellerRole(ownerId);
+
+        assertThatThrownBy(() -> service.createStore(ownerId, new CreateStoreCommand("Shop", "shop", null)))
+                .isSameAs(upstream);
+    }
+
+    @Test
+    void createStore_gatewayThrowsRuntime_wrapsWithServiceUnavailable() {
+        UUID ownerId = UUID.randomUUID();
+        when(storeProfiles.existsByOwnerId(ownerId)).thenReturn(false);
+        when(storeProfiles.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        doThrow(new IllegalStateException("oops")).when(sellerRoleGateway).ensureSellerRole(ownerId);
+
+        assertThatThrownBy(() -> service.createStore(ownerId, new CreateStoreCommand("Shop", "shop", null)))
+                .isInstanceOf(ApiException.class)
+                .hasMessageContaining("iam_unavailable");
+    }
+
+    @Test
+    void updateStore_updatesEditableFields() {
+        UUID ownerId = UUID.randomUUID();
+        UUID storeId = UUID.randomUUID();
+        Instant created = Instant.parse("2024-01-01T00:00:00Z");
+        StoreProfile store = StoreProfile.builder()
+                .id(storeId)
+                .ownerId(ownerId)
+                .name("Old")
+                .slug("old")
+                .description("old")
+                .active(false)
+                .createdAt(created)
+                .updatedAt(created)
+                .build();
+        when(storeProfiles.findByIdAndOwnerId(storeId, ownerId)).thenReturn(Optional.of(store));
+        ArgumentCaptor<StoreProfile> captor = ArgumentCaptor.forClass(StoreProfile.class);
+        when(storeProfiles.save(captor.capture())).thenAnswer(inv -> inv.getArgument(0));
+
+        StoreProfile result = service.updateStore(ownerId, storeId, new UpdateStoreCommand("New", "new", "desc", true));
+
+        assertThat(result.getName()).isEqualTo("New");
+        assertThat(result.getSlug()).isEqualTo("new");
+        assertThat(result.getDescription()).isEqualTo("desc");
+        assertThat(result.isActive()).isTrue();
+        assertThat(result.getUpdatedAt()).isNotNull().isAfter(created);
+        assertThat(captor.getValue().getUpdatedAt()).isEqualTo(result.getUpdatedAt());
+    }
+
+    @Test
+    void updateStore_notFoundThrowsApiException() {
+        UUID ownerId = UUID.randomUUID();
+        UUID storeId = UUID.randomUUID();
+        when(storeProfiles.findByIdAndOwnerId(storeId, ownerId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.updateStore(ownerId, storeId, new UpdateStoreCommand(null, null, null, null)))
+                .isInstanceOf(ApiException.class)
+                .hasMessageContaining("store_not_found");
+    }
+}

--- a/profile-service/src/test/java/com/example/profile/application/profile/ProfileQueryServiceTest.java
+++ b/profile-service/src/test/java/com/example/profile/application/profile/ProfileQueryServiceTest.java
@@ -1,0 +1,114 @@
+package com.example.profile.application.profile;
+
+import com.example.common.web.error.ApiException;
+import com.example.profile.domain.avatar.AvatarStorageService;
+import com.example.profile.domain.common.PresignedUrl;
+import com.example.profile.domain.profile.UserProfile;
+import com.example.profile.domain.profile.UserProfileRepository;
+import com.example.profile.domain.store.StoreProfile;
+import com.example.profile.domain.store.StoreProfileRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class ProfileQueryServiceTest {
+
+    private UserProfileRepository userProfiles;
+    private StoreProfileRepository storeProfiles;
+    private AvatarStorageService avatarStorageService;
+    private ProfileQueries service;
+
+    @BeforeEach
+    void setUp() {
+        userProfiles = mock(UserProfileRepository.class);
+        storeProfiles = mock(StoreProfileRepository.class);
+        avatarStorageService = mock(AvatarStorageService.class);
+        service = new ProfileQueryService(userProfiles, storeProfiles, avatarStorageService);
+    }
+
+    @Test
+    void getByUserId_returnsProfile() {
+        UUID userId = UUID.randomUUID();
+        UserProfile profile = UserProfile.builder().userId(userId).fullName("Alice").build();
+        when(userProfiles.findByUserId(userId)).thenReturn(Optional.of(profile));
+
+        UserProfile result = service.getByUserId(userId);
+
+        assertThat(result).isSameAs(profile);
+    }
+
+    @Test
+    void getByUserId_missingThrowsNotFound() {
+        UUID userId = UUID.randomUUID();
+        when(userProfiles.findByUserId(userId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getByUserId(userId))
+                .isInstanceOf(ApiException.class)
+                .hasMessageContaining("profile_not_found");
+    }
+
+    @Test
+    void listStores_delegatesToRepository() {
+        UUID ownerId = UUID.randomUUID();
+        List<StoreProfile> stores = List.of(StoreProfile.builder().ownerId(ownerId).name("Shop").build());
+        when(storeProfiles.findByOwnerId(ownerId)).thenReturn(stores);
+
+        List<StoreProfile> result = service.listStores(ownerId);
+
+        assertThat(result).isEqualTo(stores);
+    }
+
+    @Test
+    void getAvatarView_returnsPresignedUrl() {
+        UUID userId = UUID.randomUUID();
+        UserProfile profile = UserProfile.builder()
+                .userId(userId)
+                .avatarObjectKey("avatars/u.png")
+                .build();
+        PresignedUrl presignedUrl = PresignedUrl.builder()
+                .url("https://cdn/avatar")
+                .method("GET")
+                .expiresAt(Instant.now().plusSeconds(60))
+                .build();
+        when(userProfiles.findByUserId(userId)).thenReturn(Optional.of(profile));
+        when(avatarStorageService.prepareView("avatars/u.png")).thenReturn(Optional.of(presignedUrl));
+
+        PresignedUrl result = service.getAvatarView(userId);
+
+        assertThat(result).isSameAs(presignedUrl);
+    }
+
+    @Test
+    void getAvatarView_missingAvatarKeyThrowsNotFound() {
+        UUID userId = UUID.randomUUID();
+        UserProfile profile = UserProfile.builder().userId(userId).avatarObjectKey(" ").build();
+        when(userProfiles.findByUserId(userId)).thenReturn(Optional.of(profile));
+
+        assertThatThrownBy(() -> service.getAvatarView(userId))
+                .isInstanceOf(ApiException.class)
+                .hasMessageContaining("avatar_not_found");
+        verifyNoInteractions(avatarStorageService);
+    }
+
+    @Test
+    void getAvatarView_storageUnavailableThrowsServiceUnavailable() {
+        UUID userId = UUID.randomUUID();
+        UserProfile profile = UserProfile.builder()
+                .userId(userId)
+                .avatarObjectKey("avatars/u.png")
+                .build();
+        when(userProfiles.findByUserId(userId)).thenReturn(Optional.of(profile));
+        when(avatarStorageService.prepareView("avatars/u.png")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getAvatarView(userId))
+                .isInstanceOf(ApiException.class)
+                .hasMessageContaining("avatar_unavailable");
+    }
+}

--- a/profile-service/src/test/java/com/example/profile/infrastructure/iam/IamSellerRoleGatewayTest.java
+++ b/profile-service/src/test/java/com/example/profile/infrastructure/iam/IamSellerRoleGatewayTest.java
@@ -1,0 +1,125 @@
+package com.example.profile.infrastructure.iam;
+
+import com.example.common.web.error.ApiException;
+import com.example.profile.config.ProfileIamProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class IamSellerRoleGatewayTest {
+
+    private RestTemplate restTemplate;
+    private ProfileIamProperties properties;
+    private IamSellerRoleGateway gateway;
+
+    @BeforeEach
+    void setUp() {
+        restTemplate = mock(RestTemplate.class);
+        properties = new ProfileIamProperties();
+        properties.setBaseUrl("http://iam");
+        properties.setInternalAuthValue("secret");
+        gateway = new IamSellerRoleGateway(restTemplate, properties);
+    }
+
+    @Test
+    void ensureSellerRole_alreadyAssigned_skipsAssignment() {
+        String rolesUrl = properties.getBaseUrl() + properties.getRolesPath();
+        when(restTemplate.exchange(eq(rolesUrl), eq(HttpMethod.GET), any(HttpEntity.class), any(ParameterizedTypeReference.class), anyMap()))
+                .thenReturn(ResponseEntity.ok(List.of("seller")));
+
+        gateway.ensureSellerRole(UUID.randomUUID());
+
+        verify(restTemplate, never()).exchange(eq(properties.getBaseUrl() + properties.getAssignRolePath()), eq(HttpMethod.POST), any(HttpEntity.class), eq(Void.class), anyMap());
+    }
+
+    @Test
+    void ensureSellerRole_withConfiguredRoleId_assignsRole() {
+        properties.setSellerRoleId(42L);
+        String rolesUrl = properties.getBaseUrl() + properties.getRolesPath();
+        String assignUrl = properties.getBaseUrl() + properties.getAssignRolePath();
+        when(restTemplate.exchange(eq(rolesUrl), eq(HttpMethod.GET), any(HttpEntity.class), any(ParameterizedTypeReference.class), anyMap()))
+                .thenReturn(ResponseEntity.ok(List.of()));
+        ArgumentCaptor<HttpEntity<?>> entityCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+        when(restTemplate.exchange(eq(assignUrl), eq(HttpMethod.POST), entityCaptor.capture(), eq(Void.class), anyMap()))
+                .thenReturn(ResponseEntity.ok().build());
+
+        gateway.ensureSellerRole(UUID.randomUUID());
+
+        HttpHeaders headers = entityCaptor.getValue().getHeaders();
+        assertThat(headers.getFirst(properties.getInternalAuthHeader())).isEqualTo("secret");
+        assertThat(headers.getAccept()).contains(MediaType.APPLICATION_JSON);
+    }
+
+    @Test
+    void ensureSellerRole_fetchesRoleFromIamWhenNotConfigured() {
+        String rolesUrl = properties.getBaseUrl() + properties.getRolesPath();
+        String listRolesUrl = properties.getBaseUrl() + properties.getListRolesPath();
+        String assignUrl = properties.getBaseUrl() + properties.getAssignRolePath();
+        when(restTemplate.exchange(eq(rolesUrl), eq(HttpMethod.GET), any(HttpEntity.class), any(ParameterizedTypeReference.class), anyMap()))
+                .thenReturn(ResponseEntity.ok(List.of()));
+        IamRoleDto roleDto = new IamRoleDto();
+        roleDto.setId(88L);
+        roleDto.setName("SELLER");
+        when(restTemplate.exchange(eq(listRolesUrl), eq(HttpMethod.GET), any(HttpEntity.class), any(ParameterizedTypeReference.class)))
+                .thenReturn(ResponseEntity.ok(List.of(roleDto)));
+        ArgumentCaptor<Map<String, Object>> varsCaptor = ArgumentCaptor.forClass(Map.class);
+        when(restTemplate.exchange(eq(assignUrl), eq(HttpMethod.POST), any(HttpEntity.class), eq(Void.class), varsCaptor.capture()))
+                .thenReturn(ResponseEntity.ok().build());
+
+        UUID accountId = UUID.randomUUID();
+        gateway.ensureSellerRole(accountId);
+
+        assertThat(varsCaptor.getValue().get("roleId")).isEqualTo(88L);
+        assertThat(varsCaptor.getValue().get("accountId")).isEqualTo(accountId.toString());
+        verify(restTemplate).exchange(eq(listRolesUrl), eq(HttpMethod.GET), any(HttpEntity.class), any(ParameterizedTypeReference.class));
+
+        clearInvocations(restTemplate);
+        when(restTemplate.exchange(eq(rolesUrl), eq(HttpMethod.GET), any(HttpEntity.class), any(ParameterizedTypeReference.class), anyMap()))
+                .thenReturn(ResponseEntity.ok(List.of()));
+
+        gateway.ensureSellerRole(UUID.randomUUID());
+
+        verify(restTemplate, never()).exchange(eq(listRolesUrl), eq(HttpMethod.GET), any(HttpEntity.class), any(ParameterizedTypeReference.class));
+    }
+
+    @Test
+    void ensureSellerRole_roleMissingThrowsServiceUnavailable() {
+        String rolesUrl = properties.getBaseUrl() + properties.getRolesPath();
+        String listRolesUrl = properties.getBaseUrl() + properties.getListRolesPath();
+        when(restTemplate.exchange(eq(rolesUrl), eq(HttpMethod.GET), any(HttpEntity.class), any(ParameterizedTypeReference.class), anyMap()))
+                .thenReturn(ResponseEntity.ok(List.of()));
+        when(restTemplate.exchange(eq(listRolesUrl), eq(HttpMethod.GET), any(HttpEntity.class), any(ParameterizedTypeReference.class)))
+                .thenReturn(ResponseEntity.ok(List.of()));
+
+        assertThatThrownBy(() -> gateway.ensureSellerRole(UUID.randomUUID()))
+                .isInstanceOf(ApiException.class)
+                .hasMessageContaining("iam_role_missing");
+    }
+
+    @Test
+    void ensureSellerRole_restClientFailureWrapped() {
+        String rolesUrl = properties.getBaseUrl() + properties.getRolesPath();
+        when(restTemplate.exchange(eq(rolesUrl), eq(HttpMethod.GET), any(HttpEntity.class), any(ParameterizedTypeReference.class), anyMap()))
+                .thenThrow(new RestClientException("down"));
+
+        assertThatThrownBy(() -> gateway.ensureSellerRole(UUID.randomUUID()))
+                .isInstanceOf(ApiException.class)
+                .hasMessageContaining("iam_unavailable");
+    }
+}

--- a/profile-service/src/test/java/com/example/profile/infrastructure/jpa/profile/UserProfileMapperTest.java
+++ b/profile-service/src/test/java/com/example/profile/infrastructure/jpa/profile/UserProfileMapperTest.java
@@ -1,0 +1,69 @@
+package com.example.profile.infrastructure.jpa.profile;
+
+import com.example.profile.domain.profile.UserProfile;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+
+class UserProfileMapperTest {
+
+    @Test
+    void toDomain_returnsNullWhenEntityNull() {
+        assertThat(UserProfileMapper.toDomain(null)).isNull();
+    }
+
+    @Test
+    void toDomain_mapsFields() {
+        Instant created = Instant.now();
+        UserProfileEntity entity = new UserProfileEntity();
+        entity.setUserId(UUID.randomUUID());
+        entity.setFullName("Alice");
+        entity.setBio("bio");
+        entity.setPhone("123");
+        entity.setAvatarObjectKey("avatars/a.png");
+        entity.setCreatedAt(created);
+        entity.setUpdatedAt(created.plusSeconds(10));
+
+        UserProfile profile = UserProfileMapper.toDomain(entity);
+
+        assertThat(profile.getUserId()).isEqualTo(entity.getUserId());
+        assertThat(profile.getFullName()).isEqualTo("Alice");
+        assertThat(profile.getBio()).isEqualTo("bio");
+        assertThat(profile.getPhone()).isEqualTo("123");
+        assertThat(profile.getAvatarObjectKey()).isEqualTo("avatars/a.png");
+        assertThat(profile.getCreatedAt()).isEqualTo(created);
+        assertThat(profile.getUpdatedAt()).isEqualTo(created.plusSeconds(10));
+    }
+
+    @Test
+    void toEntity_returnsNullWhenProfileNull() {
+        assertThat(UserProfileMapper.toEntity(null)).isNull();
+    }
+
+    @Test
+    void toEntity_mapsFields() {
+        Instant created = Instant.parse("2024-05-01T00:00:00Z");
+        UserProfile profile = UserProfile.builder()
+                .userId(UUID.randomUUID())
+                .fullName("Alice")
+                .bio("bio")
+                .phone("123")
+                .avatarObjectKey("avatars/a.png")
+                .createdAt(created)
+                .updatedAt(created.plusSeconds(5))
+                .build();
+
+        UserProfileEntity entity = UserProfileMapper.toEntity(profile);
+
+        assertThat(entity.getUserId()).isEqualTo(profile.getUserId());
+        assertThat(entity.getFullName()).isEqualTo("Alice");
+        assertThat(entity.getBio()).isEqualTo("bio");
+        assertThat(entity.getPhone()).isEqualTo("123");
+        assertThat(entity.getAvatarObjectKey()).isEqualTo("avatars/a.png");
+        assertThat(entity.getCreatedAt()).isEqualTo(created);
+        assertThat(entity.getUpdatedAt()).isEqualTo(created.plusSeconds(5));
+    }
+}

--- a/profile-service/src/test/java/com/example/profile/infrastructure/jpa/profile/UserProfileRepositoryImplTest.java
+++ b/profile-service/src/test/java/com/example/profile/infrastructure/jpa/profile/UserProfileRepositoryImplTest.java
@@ -1,0 +1,78 @@
+package com.example.profile.infrastructure.jpa.profile;
+
+import com.example.profile.domain.profile.UserProfile;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class UserProfileRepositoryImplTest {
+
+    private JpaUserProfileRepository jpaRepository;
+    private UserProfileRepositoryImpl repository;
+
+    @BeforeEach
+    void setUp() {
+        jpaRepository = mock(JpaUserProfileRepository.class);
+        repository = new UserProfileRepositoryImpl(jpaRepository);
+    }
+
+    @Test
+    void findByUserId_mapsEntity() {
+        UUID userId = UUID.randomUUID();
+        UserProfileEntity entity = new UserProfileEntity();
+        entity.setUserId(userId);
+        entity.setFullName("Alice");
+        when(jpaRepository.findByUserId(userId)).thenReturn(Optional.of(entity));
+
+        Optional<UserProfile> result = repository.findByUserId(userId);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getUserId()).isEqualTo(userId);
+    }
+
+    @Test
+    void findByUserId_returnsEmptyWhenMissing() {
+        UUID userId = UUID.randomUUID();
+        when(jpaRepository.findByUserId(userId)).thenReturn(Optional.empty());
+
+        Optional<UserProfile> result = repository.findByUserId(userId);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void save_convertsEntity() {
+        UUID userId = UUID.randomUUID();
+        Instant now = Instant.parse("2024-06-01T00:00:00Z");
+        UserProfile profile = UserProfile.builder()
+                .userId(userId)
+                .fullName("Alice")
+                .bio("bio")
+                .phone("123")
+                .avatarObjectKey("avatars/a.png")
+                .createdAt(now)
+                .updatedAt(now.plusSeconds(1))
+                .build();
+        UserProfileEntity savedEntity = new UserProfileEntity();
+        savedEntity.setUserId(userId);
+        savedEntity.setFullName("Saved");
+        savedEntity.setCreatedAt(now);
+        savedEntity.setUpdatedAt(now.plusSeconds(2));
+        when(jpaRepository.save(any(UserProfileEntity.class))).thenReturn(savedEntity);
+
+        UserProfile result = repository.save(profile);
+
+        ArgumentCaptor<UserProfileEntity> captor = ArgumentCaptor.forClass(UserProfileEntity.class);
+        verify(jpaRepository).save(captor.capture());
+        assertThat(captor.getValue().getFullName()).isEqualTo("Alice");
+        assertThat(result.getFullName()).isEqualTo("Saved");
+        assertThat(result.getUpdatedAt()).isEqualTo(now.plusSeconds(2));
+    }
+}

--- a/profile-service/src/test/java/com/example/profile/infrastructure/jpa/store/StoreProfileMapperTest.java
+++ b/profile-service/src/test/java/com/example/profile/infrastructure/jpa/store/StoreProfileMapperTest.java
@@ -1,0 +1,73 @@
+package com.example.profile.infrastructure.jpa.store;
+
+import com.example.profile.domain.store.StoreProfile;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+
+class StoreProfileMapperTest {
+
+    @Test
+    void toDomain_returnsNullWhenEntityNull() {
+        assertThat(StoreProfileMapper.toDomain(null)).isNull();
+    }
+
+    @Test
+    void toDomain_mapsAllFields() {
+        Instant now = Instant.now();
+        StoreProfileEntity entity = new StoreProfileEntity();
+        entity.setId(UUID.randomUUID());
+        entity.setOwnerId(UUID.randomUUID());
+        entity.setName("Shop");
+        entity.setSlug("shop");
+        entity.setDescription("desc");
+        entity.setActive(true);
+        entity.setCreatedAt(now);
+        entity.setUpdatedAt(now.plusSeconds(5));
+
+        StoreProfile profile = StoreProfileMapper.toDomain(entity);
+
+        assertThat(profile.getId()).isEqualTo(entity.getId());
+        assertThat(profile.getOwnerId()).isEqualTo(entity.getOwnerId());
+        assertThat(profile.getName()).isEqualTo("Shop");
+        assertThat(profile.getSlug()).isEqualTo("shop");
+        assertThat(profile.getDescription()).isEqualTo("desc");
+        assertThat(profile.isActive()).isTrue();
+        assertThat(profile.getCreatedAt()).isEqualTo(now);
+        assertThat(profile.getUpdatedAt()).isEqualTo(now.plusSeconds(5));
+    }
+
+    @Test
+    void toEntity_returnsNullWhenProfileNull() {
+        assertThat(StoreProfileMapper.toEntity(null)).isNull();
+    }
+
+    @Test
+    void toEntity_mapsAllFields() {
+        Instant created = Instant.parse("2024-01-01T00:00:00Z");
+        StoreProfile profile = StoreProfile.builder()
+                .id(UUID.randomUUID())
+                .ownerId(UUID.randomUUID())
+                .name("Shop")
+                .slug("shop")
+                .description("desc")
+                .active(true)
+                .createdAt(created)
+                .updatedAt(created.plusSeconds(30))
+                .build();
+
+        StoreProfileEntity entity = StoreProfileMapper.toEntity(profile);
+
+        assertThat(entity.getId()).isEqualTo(profile.getId());
+        assertThat(entity.getOwnerId()).isEqualTo(profile.getOwnerId());
+        assertThat(entity.getName()).isEqualTo("Shop");
+        assertThat(entity.getSlug()).isEqualTo("shop");
+        assertThat(entity.getDescription()).isEqualTo("desc");
+        assertThat(entity.isActive()).isTrue();
+        assertThat(entity.getCreatedAt()).isEqualTo(created);
+        assertThat(entity.getUpdatedAt()).isEqualTo(created.plusSeconds(30));
+    }
+}

--- a/profile-service/src/test/java/com/example/profile/infrastructure/jpa/store/StoreProfileRepositoryImplTest.java
+++ b/profile-service/src/test/java/com/example/profile/infrastructure/jpa/store/StoreProfileRepositoryImplTest.java
@@ -1,0 +1,127 @@
+package com.example.profile.infrastructure.jpa.store;
+
+import com.example.profile.domain.store.StoreProfile;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class StoreProfileRepositoryImplTest {
+
+    private JpaStoreProfileRepository jpaRepository;
+    private StoreProfileRepositoryImpl repository;
+
+    @BeforeEach
+    void setUp() {
+        jpaRepository = mock(JpaStoreProfileRepository.class);
+        repository = new StoreProfileRepositoryImpl(jpaRepository);
+    }
+
+    @Test
+    void save_convertsToEntityAndBack() {
+        UUID id = UUID.randomUUID();
+        Instant now = Instant.parse("2024-01-01T00:00:00Z");
+        StoreProfile profile = StoreProfile.builder()
+                .id(id)
+                .ownerId(UUID.randomUUID())
+                .name("Shop")
+                .slug("shop")
+                .description("desc")
+                .active(true)
+                .createdAt(now)
+                .updatedAt(now.plusSeconds(5))
+                .build();
+        StoreProfileEntity savedEntity = new StoreProfileEntity();
+        savedEntity.setId(id);
+        savedEntity.setOwnerId(profile.getOwnerId());
+        savedEntity.setName("Saved");
+        savedEntity.setSlug("saved");
+        savedEntity.setDescription("saved-desc");
+        savedEntity.setActive(false);
+        savedEntity.setCreatedAt(now);
+        savedEntity.setUpdatedAt(now.plusSeconds(10));
+        when(jpaRepository.save(any(StoreProfileEntity.class))).thenReturn(savedEntity);
+
+        StoreProfile result = repository.save(profile);
+
+        ArgumentCaptor<StoreProfileEntity> captor = ArgumentCaptor.forClass(StoreProfileEntity.class);
+        verify(jpaRepository).save(captor.capture());
+        StoreProfileEntity persisted = captor.getValue();
+        assertThat(persisted.getId()).isEqualTo(profile.getId());
+        assertThat(persisted.getOwnerId()).isEqualTo(profile.getOwnerId());
+        assertThat(persisted.getName()).isEqualTo("Shop");
+        assertThat(result.getName()).isEqualTo("Saved");
+        assertThat(result.isActive()).isFalse();
+    }
+
+    @Test
+    void findByOwnerId_mapsResultsToDomain() {
+        UUID ownerId = UUID.randomUUID();
+        StoreProfileEntity entity = new StoreProfileEntity();
+        entity.setId(UUID.randomUUID());
+        entity.setOwnerId(ownerId);
+        entity.setName("Shop");
+        entity.setSlug("shop");
+        entity.setActive(true);
+        entity.setCreatedAt(Instant.now());
+        entity.setUpdatedAt(Instant.now());
+        when(jpaRepository.findByOwnerId(ownerId)).thenReturn(List.of(entity));
+
+        List<StoreProfile> results = repository.findByOwnerId(ownerId);
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).getOwnerId()).isEqualTo(ownerId);
+    }
+
+    @Test
+    void findByOwnerId_returnsEmptyListWhenNoneFound() {
+        UUID ownerId = UUID.randomUUID();
+        when(jpaRepository.findByOwnerId(ownerId)).thenReturn(List.of());
+
+        List<StoreProfile> results = repository.findByOwnerId(ownerId);
+
+        assertThat(results).isEmpty();
+    }
+
+    @Test
+    void findByIdAndOwnerId_mapsOptional() {
+        UUID ownerId = UUID.randomUUID();
+        UUID storeId = UUID.randomUUID();
+        StoreProfileEntity entity = new StoreProfileEntity();
+        entity.setId(storeId);
+        entity.setOwnerId(ownerId);
+        when(jpaRepository.findByIdAndOwnerId(storeId, ownerId)).thenReturn(Optional.of(entity));
+
+        Optional<StoreProfile> result = repository.findByIdAndOwnerId(storeId, ownerId);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getId()).isEqualTo(storeId);
+    }
+
+    @Test
+    void findByIdAndOwnerId_returnsEmptyWhenMissing() {
+        UUID ownerId = UUID.randomUUID();
+        UUID storeId = UUID.randomUUID();
+        when(jpaRepository.findByIdAndOwnerId(storeId, ownerId)).thenReturn(Optional.empty());
+
+        Optional<StoreProfile> result = repository.findByIdAndOwnerId(storeId, ownerId);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void existsByOwnerId_delegatesToJpa() {
+        UUID ownerId = UUID.randomUUID();
+        when(jpaRepository.existsByOwnerId(ownerId)).thenReturn(true);
+
+        assertThat(repository.existsByOwnerId(ownerId)).isTrue();
+        verify(jpaRepository).existsByOwnerId(ownerId);
+    }
+}

--- a/profile-service/src/test/java/com/example/profile/infrastructure/kafka/AccountRegisteredListenerTest.java
+++ b/profile-service/src/test/java/com/example/profile/infrastructure/kafka/AccountRegisteredListenerTest.java
@@ -1,0 +1,31 @@
+package com.example.profile.infrastructure.kafka;
+
+import com.example.common.messaging.AccountRegisteredEvent;
+import com.example.profile.application.registration.AccountRegistrationHandler;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class AccountRegisteredListenerTest {
+
+    private final AccountRegistrationHandler handler = mock(AccountRegistrationHandler.class);
+    private final AccountRegisteredListener listener = new AccountRegisteredListener(handler);
+
+    @Test
+    void consume_delegatesToHandler() {
+        AccountRegisteredEvent event = new AccountRegisteredEvent(
+                UUID.randomUUID(),
+                "user",
+                "user@example.com",
+                "User",
+                "+628123456789"
+        );
+
+        listener.consume(event);
+
+        verify(handler).handle(event);
+    }
+}

--- a/profile-service/src/test/java/com/example/profile/infrastructure/kafka/KafkaConsumerConfigTest.java
+++ b/profile-service/src/test/java/com/example/profile/infrastructure/kafka/KafkaConsumerConfigTest.java
@@ -1,0 +1,52 @@
+package com.example.profile.infrastructure.kafka;
+
+import com.example.common.messaging.AccountRegisteredEvent;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class KafkaConsumerConfigTest {
+
+    private final KafkaConsumerConfig config = new KafkaConsumerConfig();
+
+    @Test
+    void accountRegisteredConsumerFactory_configuresJsonDeserializer() {
+        KafkaProperties props = new KafkaProperties();
+        props.setBootstrapServers(List.of("localhost:9092"));
+
+        ConsumerFactory<String, AccountRegisteredEvent> factory = config.accountRegisteredConsumerFactory(props);
+
+        assertThat(factory).isNotNull();
+        assertThat(factory).isInstanceOfSatisfying(
+                org.springframework.kafka.core.DefaultKafkaConsumerFactory.class,
+                created -> assertThat(created.getValueDeserializer()).isInstanceOf(JsonDeserializer.class)
+        );
+    }
+
+    @Test
+    void accountRegisteredKafkaListenerContainerFactory_setsRecordAckMode() {
+        KafkaTemplate<Object, Object> template = mock(KafkaTemplate.class);
+        DeadLetterPublishingRecoverer recoverer = config.profileDeadLetterPublishingRecoverer(template);
+        DefaultErrorHandler errorHandler = config.profileKafkaErrorHandler(recoverer);
+
+        @SuppressWarnings("unchecked")
+        ConsumerFactory<String, AccountRegisteredEvent> consumerFactory =
+                (ConsumerFactory<String, AccountRegisteredEvent>) mock(ConsumerFactory.class);
+
+        ConcurrentKafkaListenerContainerFactory<String, AccountRegisteredEvent> factory =
+                config.accountRegisteredKafkaListenerContainerFactory(consumerFactory, errorHandler);
+
+        assertThat(factory.getContainerProperties().getAckMode()).isEqualTo(ContainerProperties.AckMode.RECORD);
+    }
+}

--- a/profile-service/src/test/java/com/example/profile/infrastructure/minio/MinioAvatarStorageServiceTest.java
+++ b/profile-service/src/test/java/com/example/profile/infrastructure/minio/MinioAvatarStorageServiceTest.java
@@ -1,0 +1,137 @@
+package com.example.profile.infrastructure.minio;
+
+import com.example.common.web.error.ApiException;
+import com.example.profile.config.AvatarStorageProperties;
+import com.example.profile.domain.common.PresignedUrl;
+import io.minio.BucketExistsArgs;
+import io.minio.GetPresignedObjectUrlArgs;
+import io.minio.MakeBucketArgs;
+import io.minio.MinioClient;
+import io.minio.RemoveObjectArgs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class MinioAvatarStorageServiceTest {
+
+    private MinioClient client;
+    private AvatarStorageProperties properties;
+    private MinioAvatarStorageService service;
+
+    @BeforeEach
+    void setUp() {
+        client = mock(MinioClient.class);
+        properties = new AvatarStorageProperties();
+        properties.setBucket("avatars");
+        properties.setPrefix("tenant");
+        properties.setUploadExpirySeconds(600);
+        properties.setViewExpirySeconds(120);
+        service = new MinioAvatarStorageService(client, properties);
+    }
+
+    @Test
+    void prepareUpload_successEnsuresBucketAndReturnsUrl() throws Exception {
+        UUID userId = UUID.randomUUID();
+        when(client.bucketExists(any(BucketExistsArgs.class))).thenReturn(true);
+        when(client.getPresignedObjectUrl(any(GetPresignedObjectUrlArgs.class))).thenReturn("https://minio/upload");
+
+        PresignedUrl url = service.prepareUpload(userId, "photo.jpg", "image/jpeg");
+
+        assertThat(url.getUrl()).isEqualTo("https://minio/upload");
+        assertThat(url.getMethod()).isEqualTo("PUT");
+        assertThat(url.getHeaders()).containsEntry("Content-Type", "image/jpeg");
+        assertThat(url.getObjectKey()).startsWith("tenant/")
+                .contains(userId.toString())
+                .endsWith(".jpg");
+        assertThat(url.getExpiresAt()).isAfter(Instant.now());
+        verify(client).bucketExists(any(BucketExistsArgs.class));
+    }
+
+    @Test
+    void prepareUpload_withoutExtensionFallsBackToContentType() throws Exception {
+        UUID userId = UUID.randomUUID();
+        when(client.bucketExists(any(BucketExistsArgs.class))).thenReturn(true);
+        when(client.getPresignedObjectUrl(any(GetPresignedObjectUrlArgs.class))).thenReturn("https://minio/upload");
+
+        PresignedUrl url = service.prepareUpload(userId, "avatar", "image/webp");
+
+        assertThat(url.getObjectKey()).endsWith(".webp");
+    }
+
+    @Test
+    void prepareUpload_bucketCreatedOnceWhenMissing() throws Exception {
+        UUID userId = UUID.randomUUID();
+        when(client.bucketExists(any(BucketExistsArgs.class))).thenReturn(false);
+        when(client.getPresignedObjectUrl(any(GetPresignedObjectUrlArgs.class))).thenReturn("https://minio/upload", "https://minio/upload2");
+
+        PresignedUrl first = service.prepareUpload(userId, "file.png", "image/png");
+        PresignedUrl second = service.prepareUpload(userId, "file2.png", "image/png");
+
+        assertThat(first.getUrl()).isEqualTo("https://minio/upload");
+        assertThat(second.getUrl()).isEqualTo("https://minio/upload2");
+        verify(client, times(1)).bucketExists(any(BucketExistsArgs.class));
+        verify(client, times(1)).makeBucket(any(MakeBucketArgs.class));
+    }
+
+    @Test
+    void prepareUpload_failureWrapsInApiException() throws Exception {
+        UUID userId = UUID.randomUUID();
+        when(client.bucketExists(any(BucketExistsArgs.class))).thenReturn(true);
+        when(client.getPresignedObjectUrl(any(GetPresignedObjectUrlArgs.class))).thenThrow(new RuntimeException("boom"));
+
+        assertThatThrownBy(() -> service.prepareUpload(userId, "file.png", "image/png"))
+                .isInstanceOf(ApiException.class)
+                .hasMessageContaining("avatar_storage_unavailable");
+    }
+
+    @Test
+    void prepareView_returnsUrlWhenAvailable() throws Exception {
+        when(client.bucketExists(any(BucketExistsArgs.class))).thenReturn(true);
+        when(client.getPresignedObjectUrl(any(GetPresignedObjectUrlArgs.class))).thenReturn("https://minio/view");
+
+        Optional<PresignedUrl> url = service.prepareView("tenant/object");
+
+        assertThat(url).isPresent();
+        assertThat(url.get().getMethod()).isEqualTo("GET");
+        assertThat(url.get().getHeaders()).isEqualTo(Map.of());
+        assertThat(url.get().getUrl()).isEqualTo("https://minio/view");
+    }
+
+    @Test
+    void prepareView_blankObjectKeyReturnsEmpty() {
+        assertThat(service.prepareView(null)).isEmpty();
+        assertThat(service.prepareView(" ")).isEmpty();
+        verifyNoInteractions(client);
+    }
+
+    @Test
+    void prepareView_failureReturnsEmpty() throws Exception {
+        when(client.bucketExists(any(BucketExistsArgs.class))).thenReturn(true);
+        when(client.getPresignedObjectUrl(any(GetPresignedObjectUrlArgs.class))).thenThrow(new RuntimeException("boom"));
+
+        assertThat(service.prepareView("tenant/object")).isEmpty();
+    }
+
+    @Test
+    void delete_blankKeyDoesNothing() throws Exception {
+        service.delete(null);
+        service.delete(" ");
+        verifyNoInteractions(client);
+    }
+
+    @Test
+    void delete_failuresAreSwallowed() throws Exception {
+        doThrow(new RuntimeException("boom")).when(client).removeObject(any(RemoveObjectArgs.class));
+
+        service.delete("tenant/object");
+
+        verify(client).removeObject(any(RemoveObjectArgs.class));
+    }
+}

--- a/profile-service/src/test/java/com/example/profile/web/GlobalExceptionHandlerTest.java
+++ b/profile-service/src/test/java/com/example/profile/web/GlobalExceptionHandlerTest.java
@@ -1,0 +1,139 @@
+package com.example.profile.web;
+
+import com.example.common.web.error.ApiException;
+import com.example.common.web.response.ErrorProps;
+import com.example.common.web.response.ErrorResponseBuilder;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import org.hibernate.validator.internal.engine.path.PathImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class GlobalExceptionHandlerTest {
+
+    private GlobalExceptionHandler handler;
+    private MockHttpServletRequest request;
+
+    @BeforeEach
+    void setUp() {
+        ErrorProps props = new ErrorProps();
+        props.setVerbose(false);
+        handler = new GlobalExceptionHandler(new ErrorResponseBuilder(props, "profile-service"));
+        request = new MockHttpServletRequest();
+        request.setRequestURI("/api/test");
+        request.setMethod("GET");
+    }
+
+    @Test
+    void apiException_returnsCustomStatus() {
+        ApiException ex = ApiException.conflict("conflict", "Conflict");
+        ResponseEntity<?> resp = handler.apiException(request, ex);
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+    }
+
+    @Test
+    void badJson_returns400() {
+        HttpMessageNotReadableException ex = new HttpMessageNotReadableException("bad", new ServletServerHttpRequest(request));
+        ResponseEntity<?> resp = handler.badJson(request, ex);
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void beanValidation_returnsFieldErrors() throws Exception {
+        Method m = Dummy.class.getDeclaredMethod("dummy", String.class);
+        MethodParameter param = new MethodParameter(m, 0);
+        BeanPropertyBindingResult result = new BeanPropertyBindingResult("t", "t");
+        result.addError(new FieldError("t", "field", "message"));
+        MethodArgumentNotValidException ex = new MethodArgumentNotValidException(param, result);
+
+        ResponseEntity<?> resp = handler.beanValidation(request, ex);
+
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    static class Dummy { void dummy(String s) {} }
+
+    @Test
+    void constraintViolation_returns400() {
+        ConstraintViolation<?> violation = mock(ConstraintViolation.class);
+        when(violation.getPropertyPath()).thenReturn(PathImpl.createPathFromString("field"));
+        when(violation.getMessage()).thenReturn("invalid");
+        ConstraintViolationException ex = new ConstraintViolationException(Set.of(violation));
+
+        ResponseEntity<?> resp = handler.constraintViolation(request, ex);
+
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void notFound_returns404() {
+        ResponseEntity<?> resp = handler.notFound(request, new NoSuchElementException());
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    void methodNotAllowed_returns405() {
+        HttpRequestMethodNotSupportedException ex = new HttpRequestMethodNotSupportedException("POST", List.of("GET"));
+        ResponseEntity<?> resp = handler.methodNotAllowed(request, ex);
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.METHOD_NOT_ALLOWED);
+    }
+
+    @Test
+    void unsupportedMediaType_returns415() {
+        HttpMediaTypeNotSupportedException ex = new HttpMediaTypeNotSupportedException(MediaType.APPLICATION_XML, List.of(MediaType.APPLICATION_JSON));
+        ResponseEntity<?> resp = handler.unsupportedMediaType(request, ex);
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    @Test
+    void dataConflict_returns409() {
+        ResponseEntity<?> resp = handler.dataConflict(request, new DataIntegrityViolationException("x"));
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+    }
+
+    @Test
+    void accessDenied_returns403() {
+        ResponseEntity<?> resp = handler.accessDenied(request, new AccessDeniedException("denied"));
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    void unknown_returns500() {
+        ResponseEntity<?> resp = handler.unknown(request, new Exception("boom"));
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @Test
+    void respond_handlesNullException() throws Exception {
+        Method respond = GlobalExceptionHandler.class.getDeclaredMethod("respond", HttpServletRequest.class, HttpStatus.class, String.class, String.class, Throwable.class, Map.class);
+        respond.setAccessible(true);
+
+        ResponseEntity<?> resp = (ResponseEntity<?>) respond.invoke(handler, request, HttpStatus.BAD_REQUEST, "code", "msg", null, null);
+
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for profile command/query services to cover application logic and error paths
- expand infrastructure coverage for IAM gateway, MinIO avatar storage, Kafka listener/configuration, and repository adapters
- exercise the web GlobalExceptionHandler to assert response mapping

## Testing
- mvn verify -Pcoverage

------
https://chatgpt.com/codex/tasks/task_e_68d8df2119dc832ebf15b19dedeb7056