### PR TITLE
fix(profile): keep store creation atomic and relax listing guard

### DIFF
--- a/profile-service/src/main/java/com/example/profile/application/profile/ProfileCommandService.java
+++ b/profile-service/src/main/java/com/example/profile/application/profile/ProfileCommandService.java
@@ -14,6 +14,7 @@ import com.example.profile.domain.store.StoreProfileRepository;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
 import java.util.Objects;
@@ -30,6 +31,7 @@ public class ProfileCommandService implements ProfileCommands {
     private final SellerRoleGateway sellerRoleGateway;
 
     @Override
+    @Transactional
     public UserProfile upsertProfile(UUID userId, UpdateProfileCommand command) {
         Objects.requireNonNull(userId, "userId");
         Objects.requireNonNull(command, "command");
@@ -70,6 +72,7 @@ public class ProfileCommandService implements ProfileCommands {
     }
 
     @Override
+    @Transactional
     public UserProfile createInitialProfile(UUID userId, CreateInitialProfileCommand command) {
         Objects.requireNonNull(userId, "userId");
         Objects.requireNonNull(command, "command");
@@ -96,6 +99,7 @@ public class ProfileCommandService implements ProfileCommands {
     }
 
     @Override
+    @Transactional
     public StoreProfile createStore(UUID ownerId, CreateStoreCommand command) {
         Objects.requireNonNull(ownerId, "ownerId");
         Objects.requireNonNull(command, "command");
@@ -130,6 +134,7 @@ public class ProfileCommandService implements ProfileCommands {
     }
 
     @Override
+    @Transactional
     public StoreProfile updateStore(UUID ownerId, UUID storeId, UpdateStoreCommand command) {
         Objects.requireNonNull(ownerId, "ownerId");
         Objects.requireNonNull(storeId, "storeId");

--- a/profile-service/src/main/java/com/example/profile/infrastructure/jpa/store/StoreProfileRepositoryImpl.java
+++ b/profile-service/src/main/java/com/example/profile/infrastructure/jpa/store/StoreProfileRepositoryImpl.java
@@ -3,7 +3,6 @@ package com.example.profile.infrastructure.jpa.store;
 import com.example.profile.domain.store.StoreProfile;
 import com.example.profile.domain.store.StoreProfileRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -15,7 +14,6 @@ public class StoreProfileRepositoryImpl implements StoreProfileRepository {
     private final JpaStoreProfileRepository jpaRepository;
 
     @Override
-    @Transactional
     public StoreProfile save(StoreProfile storeProfile) {
         StoreProfileEntity entity = StoreProfileMapper.toEntity(storeProfile);
         StoreProfileEntity saved = jpaRepository.save(entity);
@@ -23,7 +21,6 @@ public class StoreProfileRepositoryImpl implements StoreProfileRepository {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public List<StoreProfile> findByOwnerId(UUID ownerId) {
         return jpaRepository.findByOwnerId(ownerId).stream()
                 .map(StoreProfileMapper::toDomain)
@@ -31,13 +28,11 @@ public class StoreProfileRepositoryImpl implements StoreProfileRepository {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public Optional<StoreProfile> findByIdAndOwnerId(UUID id, UUID ownerId) {
         return jpaRepository.findByIdAndOwnerId(id, ownerId).map(StoreProfileMapper::toDomain);
     }
 
     @Override
-    @Transactional(readOnly = true)
     public boolean existsByOwnerId(UUID ownerId) {
         return jpaRepository.existsByOwnerId(ownerId);
     }

--- a/profile-service/src/main/java/com/example/profile/web/store/ProfileStoreController.java
+++ b/profile-service/src/main/java/com/example/profile/web/store/ProfileStoreController.java
@@ -29,7 +29,7 @@ public class ProfileStoreController implements ProfileStoreApi {
     private final ProfileQueries profileQueries;
 
     @Override
-    @PreAuthorize("hasAnyRole('SELLER','ADMIN')")
+    @PreAuthorize("hasAnyRole('CUSTOMER','SELLER','ADMIN')")
     public ResponseEntity<List<StoreProfileResponse>> listMyStores() {
         UUID userId = requireCurrentUserId();
         var stores = profileQueries.listStores(userId).stream()

--- a/profile-service/src/test/java/com/example/profile/application/profile/ProfileCommandServiceIntegrationTest.java
+++ b/profile-service/src/test/java/com/example/profile/application/profile/ProfileCommandServiceIntegrationTest.java
@@ -1,0 +1,104 @@
+package com.example.profile.application.profile;
+
+import com.example.common.web.error.ApiException;
+import com.example.profile.ProfileServiceApplication;
+import com.example.profile.domain.profile.SellerRoleGateway;
+import com.example.profile.domain.profile.UserProfile;
+import com.example.profile.domain.profile.UserProfileRepository;
+import com.example.profile.infrastructure.jpa.store.JpaStoreProfileRepository;
+import com.example.profile.infrastructure.jpa.store.StoreProfileEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestPropertySource;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+@SpringBootTest(classes = ProfileServiceApplication.class, webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:profile;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.jpa.show-sql=false",
+        "spring.jpa.properties.hibernate.format_sql=false",
+        "spring.flyway.enabled=false",
+        "eureka.client.enabled=false",
+        "spring.cloud.discovery.enabled=false",
+        "spring.main.allow-bean-definition-overriding=true",
+        "profile.avatar.endpoint=http://localhost:10000",
+        "profile.iam.internal-auth-value=test-token"
+})
+class ProfileCommandServiceIntegrationTest {
+
+    @Autowired
+    private ProfileCommands profileCommands;
+
+    @Autowired
+    private UserProfileRepository userProfiles;
+
+    @Autowired
+    private JpaStoreProfileRepository jpaStoreProfiles;
+
+    @MockBean
+    private SellerRoleGateway sellerRoleGateway;
+
+    @BeforeEach
+    void resetMocks() {
+        reset(sellerRoleGateway);
+        jpaStoreProfiles.deleteAll();
+    }
+
+    @Test
+    void createStore_rollsBackWhenRoleAssignmentFails() {
+        UUID ownerId = UUID.randomUUID();
+        userProfiles.save(UserProfile.builder()
+                .userId(ownerId)
+                .fullName("Test User")
+                .createdAt(Instant.now())
+                .updatedAt(Instant.now())
+                .build());
+
+        doThrow(ApiException.serviceUnavailable("iam_unavailable", "Failed"))
+                .when(sellerRoleGateway).ensureSellerRole(ownerId);
+
+        assertThatThrownBy(() -> profileCommands.createStore(ownerId,
+                new ProfileCommands.CreateStoreCommand("Store", "store", "desc")))
+                .isInstanceOf(ApiException.class)
+                .hasMessageContaining("iam_unavailable");
+
+        List<StoreProfileEntity> stores = jpaStoreProfiles.findByOwnerId(ownerId);
+        assertThat(stores).isEmpty();
+    }
+
+    @Test
+    void createStore_persistsStoreAndAssignsRole() {
+        UUID ownerId = UUID.randomUUID();
+        userProfiles.save(UserProfile.builder()
+                .userId(ownerId)
+                .fullName("Another User")
+                .createdAt(Instant.now())
+                .updatedAt(Instant.now())
+                .build());
+
+        profileCommands.createStore(ownerId, new ProfileCommands.CreateStoreCommand("My Shop", "my-shop", "desc"));
+
+        List<StoreProfileEntity> stores = jpaStoreProfiles.findByOwnerId(ownerId);
+        assertThat(stores).hasSize(1);
+        assertThat(stores.get(0).getSlug()).isEqualTo("my-shop");
+
+        verify(sellerRoleGateway).ensureSellerRole(ownerId);
+        verifyNoMoreInteractions(sellerRoleGateway);
+    }
+}


### PR DESCRIPTION
## Summary
- wrap profile command mutations in transactions so IAM failures roll back store creation
- remove repository-level transactions and allow customers to view their own stores
- add integration coverage proving seller role failures do not persist stores

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_e_68d908aa3484832e8ab3c2cd3d237a51